### PR TITLE
fix: z-index issue with navbar

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -28,7 +28,7 @@ function isMatch(urlPath: string, linkPath: string) {
 }
 ---
 
-<nav-open class="group block sticky z-20 top-0">
+<nav-open class="group block sticky z-40 top-0">
   <nav
     class="max-w-[80ch] mx-auto flex gap-6 items-center text-lg py-2 px-3 sm:py-3"
   >


### PR DESCRIPTION
Currently, when the whiteboard is in "drawing" mode, the navbar is behind the board because the [board has `z-30` when in drawing mode](https://github.com/bholmesdev/bholmesdev/blob/292d1230accf834921300ddf68f09a30917b2cad/src/components/heading/Heading.astro#L75) and the [navbar has `z-20`](https://github.com/bholmesdev/bholmesdev/blob/292d1230accf834921300ddf68f09a30917b2cad/src/components/Nav.astro#L31) so it is shown behind the board.

I've changed the z-index to `z-40` in the navbar to fix it.

![image](https://github.com/bholmesdev/bholmesdev/assets/61059807/7558a83b-e211-46d9-9eb9-15a91b8d7bdc)
