### PR TITLE
fix(a11y): improve WCAG compliance across components

### DIFF
--- a/src/components/LikeButton.astro
+++ b/src/components/LikeButton.astro
@@ -11,6 +11,8 @@ const { postSlug } = Astro.props;
 <RootElement data={{ postSlug }} class="flex items-center gap-4">
   <button
     data-target="button"
+    aria-label="Like this post"
+    aria-pressed="false"
     class="w-[2.5em] h-[2.5em] bg-gradient-to-br from-slate-600 to-slate-900 rounded-full flex items-center justify-center"
   >
     <div
@@ -51,6 +53,7 @@ const { postSlug } = Astro.props;
     ctx.effect(() => {
       $.self.toggleAttribute("data-liked", liked.get());
       $.self.toggleAttribute("data-pending", pending.get());
+      $("button").setAttribute("aria-pressed", liked.get().toString());
 
       if (liked.get()) {
         localStorage.setItem(`isLike:${postSlug}`, "true");

--- a/src/components/TOC.astro
+++ b/src/components/TOC.astro
@@ -37,6 +37,8 @@ const { headings } = Astro.props;
   <button
     data-target="btn"
     aria-controls={scope("panel")}
+    aria-expanded="false"
+    aria-label="Table of contents"
     class="transition-all ease-spring-3 duration-500"
   >
     <div class="inner overflow-y-hidden">
@@ -58,6 +60,7 @@ const { headings } = Astro.props;
 
     ctx.effect(() => {
       $.self.toggleAttribute("data-open", open.get());
+      $("btn").setAttribute("aria-expanded", open.get().toString());
       $<HTMLProgressElement>("progress").value = progress.get();
 
       $.self.toggleAttribute(

--- a/src/components/heading/Whiteboard.astro
+++ b/src/components/heading/Whiteboard.astro
@@ -19,8 +19,10 @@ const { $scope } = Astro.props;
     width="800"
     height="1200"
     data-target={$scope("canvas")}
+    aria-label="Interactive whiteboard for drawing"
+    role="img"
     class="absolute w-[85%] h-[85.7%] inset-y-[7%] inset-x-[10.8%] rounded-[5%]"
-  ></canvas>
+  >Your browser does not support the canvas element.</canvas>
   <div
     data-target={$scope("eraser")}
     class="absolute left-[14%] bottom-[9%] w-[13%] h-[13%]"

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -16,7 +16,8 @@ import SquooshButton from "~/components/SquooshButton.astro";
     </div>
     <article class="mt-6 md:mt-12 lg:mt-16">
       <h1 class="text-4xl mb-4 sm:mb-8 font-heading">About me</h1>
-      <input id="inbrief-checkbox" class="hidden checkbox" type="checkbox" />
+      <input id="inbrief-checkbox" class="hidden checkbox" type="checkbox" aria-describedby="mode-description" />
+      <p id="mode-description" class="sr-only">Toggle between personal and recruiter view modes</p>
       <label
         class="font-bold cursor-pointer grid gap-2 items-center justify-between text-lg text-gray-400 mb-2"
         for="inbrief-checkbox"

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -41,7 +41,7 @@ const { Content, headings } = await post.render();
                             data-crop={post.data.cropLegacy}
                             class="data-crop:aspect-[4/3] object-cover object-left w-full"
                             src={post.data.image}
-                            alt=""
+                            alt={`Cover image for ${post.data.title}`}
                         />
                     </div>
                 )


### PR DESCRIPTION
# Accessibility Audit Fixes

## Summary
This PR addresses accessibility issues identified during a WCAG compliance audit, improving screen reader support and overall usability for users with disabilities.

## Issues Fixed

### Critical (WCAG 4.1.2 - Name, Role, Value)

| Component | Issue | Fix |
|-----------|-------|-----|
| `LikeButton.astro` | Button had no accessible name | Added `aria-label="Like this post"` and `aria-pressed` state |
| `TOC.astro` | Toggle button had no accessible name | Added `aria-label="Table of contents"` and `aria-expanded` state |

### Serious (WCAG 1.1.1 - Non-text Content)

| Component | Issue | Fix |
|-----------|-------|-----|
| `blog/[...slug].astro` | Blog header images had empty alt text | Now uses post title for meaningful alt text |
| `Whiteboard.astro` | Canvas element lacked fallback | Added `aria-label`, `role="img"`, and fallback text |

### Moderate (WCAG 4.1.2)

| Component | Issue | Fix |
|-----------|-------|-----|
| `about.astro` | Hidden checkbox toggle lacked context | Added `aria-describedby` for screen reader users |

## What Was Already Good ✅

- `lang="en"` attribute on `<html>` element
- Proper use of `sr-only` class for visually hidden text
- Icons with `title` attributes
- Form inputs with labels (Newsletter component)
- Navigation with `aria-controls` and `aria-label`
- No `outline: none` removing focus indicators
- Proper heading hierarchy

## Testing Recommendations

- Test with VoiceOver (macOS) or NVDA (Windows)
- Verify keyboard navigation works for all interactive elements
- Check that `aria-expanded` and `aria-pressed` states are announced

---

_This PR was generated with [Warp](https://www.warp.dev/)._
