### PR TITLE
fix(a11y): improve color contrast for WCAG compliance

### DIFF
--- a/src/components/Newsletter.tsx
+++ b/src/components/Newsletter.tsx
@@ -32,7 +32,7 @@ export function Newsletter() {
                 name="email"
                 type="email"
                 required
-                className="rounded px-4 py-3 border-2 border-slate-700 focus:ring-0 focus:border-primary focus:outline-none transition-colors"
+className="rounded px-4 py-3 border-2 border-slate-500 focus:ring-0 focus:border-primary focus:outline-none transition-colors"
               />
               {fieldErrors.email && (
                 <p className="text-red-300">{fieldErrors.email}</p>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -114,7 +114,7 @@ const { Content, headings } = await post.render();
     }
 
     main :global(article) :global(blockquote) {
-        border-left: 4px solid var(--color-gray-900);
+        border-left: 4px solid var(--color-gray-700);
         color: var(--color-gray-300);
         padding-left: 1rem;
         margin-left: 0;
@@ -135,7 +135,7 @@ const { Content, headings } = await post.render();
         display: flex;
         z-index: -1;
         line-height: 1.3;
-        color: var(--color-gray-600);
+        color: var(--color-gray-500);
         font-size: var(--text-2xl);
         font-family: var(--font-heading);
         justify-content: center;


### PR DESCRIPTION
# Fix color contrast for WCAG compliance

## Summary
Improves color contrast ratios for elements that fail WCAG 1.4.3 (Contrast Minimum) and WCAG 1.4.11 (Non-text Contrast). This is a follow-up to #46 which addressed other accessibility concerns.

## Changes

**Blog heading counter number** (`src/pages/blog/[...slug].astro`)
- `color: gray-600` → `gray-500` on `gray-900` background
- Contrast ratio: ~2.4:1 → ~3.7:1 (passes 3:1 for large text)

**Blockquote border** (`src/pages/blog/[...slug].astro`)
- `border-color: gray-900` → `gray-700` on `gray-950` background
- Contrast ratio: ~1.1:1 → ~2.0:1 (significant visibility improvement)

**Newsletter input border** (`src/components/Newsletter.tsx`)
- `border-slate-700` → `border-slate-500` on `gray-900` background
- Contrast ratio: ~1.8:1 → ~3.8:1 (passes 3:1 for UI components)

_This PR was generated with [Warp](https://www.warp.dev/)._
