### PR TITLE
Update footer year to 2026

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -73,7 +73,7 @@ const ogImage = new URL(
         </div>
         <footer>
             <p class="text-center py-8 text-sm">
-                &copy; 2020-present Ben Holmes. All rights reserved.
+                &copy; 2020-2026 Ben Holmes. All rights reserved.
             </p>
         </footer>
         <style is:global>


### PR DESCRIPTION
Update the copyright year in the footer from "2020-present" to "2020-2026" to reflect the current year.

_This PR was generated with [Warp](https://www.warp.dev/)._

https://app.warp.dev/session/a9c1bede-c7e2-4c65-8c04-ca485f120714
