### PR TITLE
Update footer start year to 2021

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -73,7 +73,7 @@ const ogImage = new URL(
         </div>
         <footer>
             <p class="text-center py-8 text-sm">
-                &copy; 2020-2026 Ben Holmes. All rights reserved.
+                &copy; 2021-2026 Ben Holmes. All rights reserved.
             </p>
         </footer>
         <style is:global>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -73,7 +73,7 @@ const ogImage = new URL(
         </div>
         <footer>
             <p class="text-center py-8 text-sm">
-                &copy; 2020-present Ben Holmes. All rights reserved.
+                &copy; 2020-2026 Ben Holmes. All rights reserved.
             </p>
         </footer>
         <style is:global>


### PR DESCRIPTION
Update the copyright start year in the footer from 2020 to 2021.

_This PR was generated with [Warp](https://www.warp.dev/)._
