### PR TITLE
fix: remove stray </span fragment from index page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,8 +17,7 @@ import SquooshButton from "~/components/SquooshButton.astro";
         href="/about"
         class="text-lg"
       >
-        More about me <Icon name="arrow-right" /></span
-
+        More about me <Icon name="arrow-right" />
       </SquooshButton>
     </div>
   </main>


### PR DESCRIPTION
## Fix: remove stray `</span` fragment from homepage

The homepage (`src/pages/index.astro`) contained a stray `</span` closing tag fragment on line 20:
- No matching opening `<span>` tag
- Missing its closing `>`
- The `SquooshButton` component already wraps slotted content in a `<span>`, making this extraneous

This was likely leftover from a previous refactor. Build verified clean after the fix.

---

_Conversation: https://staging.warp.dev/conversation/5029ead4-1a1c-4fa0-9625-78533b98e9a9_
_Run: https://oz.staging.warp.dev/runs/019e0002-dd2d-747e-9044-eb88000c28da_
_This PR was generated with [Oz](https://warp.dev/oz)._
