### PR TITLE
fix: make footer copyright year dynamic

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -73,7 +73,7 @@ const ogImage = new URL(
         </div>
         <footer>
             <p class="text-center py-8 text-sm">
-                &copy; 2020-present Ben Holmes. All rights reserved.
+                &copy; 2020-{new Date().getFullYear()} Ben Holmes. All rights reserved.
             </p>
         </footer>
         <style is:global>


### PR DESCRIPTION
## Fix: make footer copyright year dynamic

The footer in `src/layouts/BaseLayout.astro` had a hardcoded `© 2020-present` string. This PR replaces `present` with `new Date().getFullYear()`, so the year is computed dynamically at build time and stays correct automatically.

This supersedes the static year fixes proposed in PRs #48 and #49 — no more manual updates needed.

### Change
- `src/layouts/BaseLayout.astro` line 76: `2020-present` → `2020-{new Date().getFullYear()}`

### Verification
- Site builds cleanly with `pnpm run build`

---

_Conversation: https://staging.warp.dev/conversation/2179d9cb-ec2c-4303-897c-d64bf8807027_
_Run: https://oz.staging.warp.dev/runs/019e0016-0abf-7067-bf58-559f797fabc1_
_This PR was generated with [Oz](https://warp.dev/oz)._
