### PR TITLE
Add review-pr skills and light mode palette

### DIFF
--- a/.agents/skills/improve-review-pr/SKILL.md
+++ b/.agents/skills/improve-review-pr/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: improve-review-pr
+description: Daily outer loop that reviews human reactions to automated review-pr comments, synthesizes durable organizational knowledge, and opens a PR to update the review-pr skill when the feedback is worth remembering. Use when improving code-review quality from human feedback, running a scheduled review-skill retrospective, or incorporating maintainer corrections into review guidance.
+---
+
+# Improve Review PR
+
+Run a once-per-day outer loop over the automated code-review stage.
+
+The inner loop is already running: `review-pr` comments on pull requests throughout the day. This skill is the outer loop: read how humans reacted to those comments, extract durable organizational knowledge, and update the review skill so the next inner-loop runs get better.
+
+## Goal
+
+Improve future automated reviews by learning from human validation and correction of previous `review-pr` comments.
+
+Do not re-review product code. Do not restate one-off PR opinions. Only capture knowledge that should change how the review agent behaves on future PRs.
+
+## Inputs
+
+- The current checkout of the repository that owns `.agents/skills/review-pr/SKILL.md`
+- GitHub API access via authenticated `gh`
+- Optional lookback window, default last 24 hours
+- Optional `feedback_corpus.json` produced by:
+  ```sh
+  python3 .agents/skills/improve-review-pr/scripts/collect_review_feedback.py \
+    --repo OWNER/REPO \
+    --since-hours 24 \
+    --output feedback_corpus.json
+  ```
+
+If `feedback_corpus.json` is missing, run the collector yourself before analyzing.
+
+## Workflow
+
+### 1. Collect the day's review-agent interactions
+
+Run or read `feedback_corpus.json`.
+
+The corpus should include, for the lookback window:
+
+- Pull requests that received an automated review from the review agent
+- The review agent's top-level review bodies and inline comments
+- Human replies to those comments
+- Human reactions (for example `+1`, `eyes`, `confused`, `thumbs down`) when available
+- Whether the human accepted a suggestion, dismissed it, edited around it, or explicitly disagreed
+- Whether the PR author or another reviewer later fixed the same issue, ignored it, or called it wrong
+
+Identify the review agent by login when possible (`github-actions[bot]`, a bot account, or a configured login). Prefer comments that originated from the `review-pr` publish path.
+
+### 2. Score each feedback item
+
+For each human interaction, classify the outcome:
+
+- `validated` — human agreed, accepted the suggestion, or fixed the issue as recommended
+- `corrected` — human said the finding was wrong, incomplete, too noisy, or the wrong severity
+- `refined` — human mostly agreed but adjusted the guidance, scope, or preferred pattern
+- `ambiguous` — not enough signal to learn from
+
+Ignore pure acknowledgements with no substantive judgment.
+
+### 3. Synthesize durable organizational knowledge
+
+Look across the day's validated/corrected/refined items for patterns worth remembering. Good candidates:
+
+- Repo conventions the review agent repeatedly misses
+- False-positive classes that should be demoted or avoided
+- Severity calibration mistakes
+- Preferred alternatives to common suggestions
+- Missing checks that humans keep adding manually
+- Guidance about when not to comment
+
+Reject learnings that are:
+
+- One-off to a single PR or file
+- Already covered well by `review-pr` or a local companion skill
+- Product-feature preferences unrelated to review quality
+- Temporary project constraints unlikely to recur
+- Changes that would break the review-pr output schema, severity labels, safety rules, evidence rules, suggestion-block constraints, or annotated-diff line contract
+
+Prefer a small number of high-confidence learnings over many weak ones.
+
+### 4. Decide whether to update the skill
+
+Choose exactly one outcome:
+
+- `no_changes` — no durable learning worth encoding
+- `update_review_pr` — update core `.agents/skills/review-pr/SKILL.md`
+- `update_review_pr_local` — update or create `.agents/skills/review-pr-local/SKILL.md` for repository-specific guidance
+- `both` — core and local updates are both warranted
+
+Use `review-pr-local` for repository-specific conventions. Keep portable review behavior in core `review-pr`.
+
+If no durable learning exists, stop after writing the synthesis report. Do not open an empty PR.
+
+### 5. Apply skill updates carefully
+
+When updating a skill:
+
+1. Read the current skill file completely.
+2. Make the smallest cohesive edit that captures the learning.
+3. Prefer adding or tightening guidance over rewriting large sections.
+4. Keep the existing structure, severity labels, JSON contract, and safety rules intact.
+5. Write guidance as durable rules or examples, not as a diary of today's PRs.
+6. If creating `review-pr-local`, make it a companion that specializes overridable review guidance only. Explicitly state that it must not change the core output schema or contracts.
+
+Validate that the resulting skill still clearly instructs the agent to:
+
+- write only `review.json`
+- avoid posting to GitHub directly
+- keep suggestion blocks valid
+- validate hypothesized fixes before recommending them when practical
+
+### 6. Open a skill-improvement PR when there are changes
+
+If you updated any skill file:
+
+1. Create a branch such as `improve/review-pr-YYYY-MM-DD`
+2. Commit only the skill updates and any tiny supporting docs needed to explain them
+3. Include `Co-Authored-By: Oz <oz-agent@warp.dev>` in the commit message
+4. Push and open a PR against the repository default branch
+5. In the PR body, include:
+   - Summary of the human-feedback patterns observed
+   - Exact learnings encoded
+   - Why each learning is durable
+   - Links to representative source PRs/comments
+   - Explicit non-goals / rejected candidates
+   - Note that this PR only updates review guidance, not product code
+
+Do not merge the PR. Leave it for human review.
+
+### 7. Report the result
+
+Return a concise report with:
+
+```markdown
+## Improve review-pr result
+- **Window:** last N hours
+- **PRs inspected:** count
+- **Feedback items:** count validated / corrected / refined / ambiguous
+- **Decision:** no_changes | update_review_pr | update_review_pr_local | both
+- **Learnings encoded:** bullet list, or "none"
+- **Skill PR:** URL or "not opened"
+- **Next step:** one concrete action for humans
+```
+
+If a skill PR was opened, the report must include its URL.
+
+## Guardrails
+
+- Do not update product code, tests, or unrelated skills.
+- Do not change the review-pr JSON schema, severity labels, safety rules, evidence rules, suggestion-block constraints, or annotated-diff line contract.
+- Do not open a PR for weak, one-off, or already-encoded feedback.
+- Do not invent human feedback that is not present in the corpus.
+- Do not expose secrets, tokens, private environment variables, or internal reasoning dumps.
+- Prefer local companion guidance for repo-specific conventions; keep core `review-pr` portable.
+- Keep the skill update small enough for a human to review quickly.

--- a/.agents/skills/improve-review-pr/scripts/collect_review_feedback.py
+++ b/.agents/skills/improve-review-pr/scripts/collect_review_feedback.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Collect human feedback on automated review-pr comments.
+
+Produces a JSON corpus the improve-review-pr skill can synthesize.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_BOT_LOGINS = {
+    "github-actions[bot]",
+    "github-actions",
+    "oz-agent[bot]",
+    "oz[bot]",
+    "warp[bot]",
+}
+
+REVIEW_MARKER_RE = re.compile(
+    r"(\u26a0\ufe0f\s*\[IMPORTANT\]|\U0001f6a8\s*\[CRITICAL\]|"
+    r"\U0001f4a1\s*\[SUGGESTION\]|\U0001f9f9\s*\[NIT\]|"
+    r"Found:\s*\d+\s*critical|Powered by \[Oz\])",
+    re.IGNORECASE,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Collect human feedback on automated PR review comments."
+    )
+    parser.add_argument(
+        "--repo",
+        help="OWNER/REPO. Defaults to GITHUB_REPOSITORY.",
+    )
+    parser.add_argument(
+        "--since-hours",
+        type=int,
+        default=24,
+        help="Look back this many hours from now (default: 24).",
+    )
+    parser.add_argument(
+        "--bot-login",
+        action="append",
+        default=[],
+        help="Additional bot login to treat as the review agent. Repeatable.",
+    )
+    parser.add_argument(
+        "--max-prs",
+        type=int,
+        default=50,
+        help="Maximum recently updated PRs to inspect (default: 50).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("feedback_corpus.json"),
+        help="Path to write the feedback corpus JSON.",
+    )
+    return parser.parse_args()
+
+
+def _default_repo() -> str | None:
+    return (os.environ.get("GITHUB_REPOSITORY") or "").strip() or None
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    cmd = ["gh", "api", *args]
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise SystemExit(
+            "collect_review_feedback failed:\n"
+            f"command: {' '.join(cmd)}\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+    if not result.stdout.strip():
+        return None
+    return json.loads(result.stdout)
+
+
+def _paginate(path: str, params: list[str] | None = None) -> list[Any]:
+    args = ["--paginate", path]
+    if params:
+        for item in params:
+            args.extend(["-f", item] if "=" in item and not item.startswith("per_page") else ["-F", item])
+    # Prefer query string construction for simple GETs.
+    if params:
+        query = "&".join(params)
+        path_with_query = f"{path}?{query}"
+        data = _run_gh_json(["--paginate", path_with_query])
+    else:
+        data = _run_gh_json(["--paginate", path])
+    if data is None:
+        return []
+    if isinstance(data, list):
+        return data
+    return [data]
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _is_bot_login(login: str, bot_logins: set[str]) -> bool:
+    normalized = (login or "").strip().lower()
+    if not normalized:
+        return False
+    if normalized in {item.lower() for item in bot_logins}:
+        return True
+    return normalized.endswith("[bot]")
+
+
+def _looks_like_review_agent_body(body: str) -> bool:
+    if not body:
+        return False
+    return REVIEW_MARKER_RE.search(body) is not None
+
+
+def _reaction_summary(reactions: dict[str, Any] | None) -> dict[str, int]:
+    if not isinstance(reactions, dict):
+        return {}
+    keys = ["+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"]
+    return {key: int(reactions.get(key) or 0) for key in keys if int(reactions.get(key) or 0)}
+
+
+def _classify_reply(body: str) -> str:
+    text = (body or "").strip().lower()
+    if not text:
+        return "ambiguous"
+    positive = [
+        "good catch",
+        "thanks",
+        "fixed",
+        "done",
+        "agreed",
+        "makes sense",
+        "will do",
+        "addressed",
+        "lgtm",
+        "+1",
+    ]
+    negative = [
+        "incorrect",
+        "wrong",
+        "false positive",
+        "not needed",
+        "nitpick",
+        "disagree",
+        "won't fix",
+        "will not fix",
+        "out of scope",
+        "already handled",
+        "intentional",
+    ]
+    refined = [
+        "partially",
+        "mostly",
+        "prefer",
+        "instead",
+        "alternative",
+        "we usually",
+        "in this repo",
+        "convention",
+    ]
+    if any(token in text for token in negative):
+        return "corrected"
+    if any(token in text for token in refined):
+        return "refined"
+    if any(token in text for token in positive):
+        return "validated"
+    if len(text) < 12:
+        return "ambiguous"
+    return "refined"
+
+
+def _list_recent_prs(owner: str, repo: str, since: datetime, max_prs: int) -> list[dict[str, Any]]:
+    # Search recently updated PRs; still filter client-side by since.
+    query = f"repo:{owner}/{repo} is:pr updated:>={since.date().isoformat()}"
+    data = _run_gh_json(
+        [
+            f"search/issues?q={query.replace(' ', '+')}&sort=updated&order=desc&per_page={max_prs}"
+        ]
+    )
+    items = data.get("items") if isinstance(data, dict) else None
+    if not isinstance(items, list):
+        return []
+    prs: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        updated = _parse_dt(str(item.get("updated_at") or ""))
+        if updated is not None and updated < since:
+            continue
+        prs.append(item)
+    return prs[:max_prs]
+
+
+def _collect_for_pr(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    *,
+    since: datetime,
+    bot_logins: set[str],
+) -> dict[str, Any]:
+    reviews = _paginate(f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews")
+    review_comments = _paginate(f"/repos/{owner}/{repo}/pulls/{pr_number}/comments")
+    issue_comments = _paginate(f"/repos/{owner}/{repo}/issues/{pr_number}/comments")
+
+    agent_reviews: list[dict[str, Any]] = []
+    for review in reviews:
+        if not isinstance(review, dict):
+            continue
+        user = ((review.get("user") or {}).get("login") or "").strip()
+        body = str(review.get("body") or "")
+        submitted = _parse_dt(str(review.get("submitted_at") or ""))
+        if submitted is not None and submitted < since:
+            # Keep older agent reviews only if later human replies reference them.
+            pass
+        if _is_bot_login(user, bot_logins) or _looks_like_review_agent_body(body):
+            agent_reviews.append(
+                {
+                    "id": review.get("id"),
+                    "user": user,
+                    "state": review.get("state"),
+                    "submitted_at": review.get("submitted_at"),
+                    "body": body,
+                    "html_url": review.get("html_url"),
+                }
+            )
+
+    agent_comment_ids: set[int] = set()
+    agent_inline_comments: list[dict[str, Any]] = []
+    for comment in review_comments:
+        if not isinstance(comment, dict):
+            continue
+        user = ((comment.get("user") or {}).get("login") or "").strip()
+        body = str(comment.get("body") or "")
+        comment_id = comment.get("id")
+        created = _parse_dt(str(comment.get("created_at") or ""))
+        is_agent = _is_bot_login(user, bot_logins) or _looks_like_review_agent_body(body)
+        if not is_agent:
+            continue
+        if isinstance(comment_id, int):
+            agent_comment_ids.add(comment_id)
+        agent_inline_comments.append(
+            {
+                "id": comment_id,
+                "user": user,
+                "created_at": comment.get("created_at"),
+                "updated_at": comment.get("updated_at"),
+                "path": comment.get("path"),
+                "line": comment.get("line") or comment.get("original_line"),
+                "side": comment.get("side"),
+                "body": body,
+                "html_url": comment.get("html_url"),
+                "in_reply_to_id": comment.get("in_reply_to_id"),
+                "reactions": _reaction_summary(comment.get("reactions")),
+                "in_window": bool(created is None or created >= since),
+            }
+        )
+
+    human_replies: list[dict[str, Any]] = []
+    for comment in review_comments:
+        if not isinstance(comment, dict):
+            continue
+        user = ((comment.get("user") or {}).get("login") or "").strip()
+        if _is_bot_login(user, bot_logins):
+            continue
+        in_reply_to = comment.get("in_reply_to_id")
+        created = _parse_dt(str(comment.get("created_at") or ""))
+        if created is not None and created < since:
+            continue
+        if isinstance(in_reply_to, int) and in_reply_to in agent_comment_ids:
+            body = str(comment.get("body") or "")
+            human_replies.append(
+                {
+                    "id": comment.get("id"),
+                    "user": user,
+                    "created_at": comment.get("created_at"),
+                    "body": body,
+                    "html_url": comment.get("html_url"),
+                    "in_reply_to_id": in_reply_to,
+                    "classification": _classify_reply(body),
+                    "source": "inline_reply",
+                }
+            )
+
+    # Issue comments that appear to respond to agent reviews in-window.
+    for comment in issue_comments:
+        if not isinstance(comment, dict):
+            continue
+        user = ((comment.get("user") or {}).get("login") or "").strip()
+        if _is_bot_login(user, bot_logins):
+            continue
+        created = _parse_dt(str(comment.get("created_at") or ""))
+        if created is not None and created < since:
+            continue
+        body = str(comment.get("body") or "")
+        if not body:
+            continue
+        # Keep only comments that clearly engage with review findings.
+        if not any(
+            token in body.lower()
+            for token in [
+                "review",
+                "nit",
+                "suggestion",
+                "false positive",
+                "good catch",
+                "bot",
+                "oz",
+                "critical",
+                "important",
+            ]
+        ):
+            continue
+        human_replies.append(
+            {
+                "id": comment.get("id"),
+                "user": user,
+                "created_at": comment.get("created_at"),
+                "body": body,
+                "html_url": comment.get("html_url"),
+                "in_reply_to_id": None,
+                "classification": _classify_reply(body),
+                "source": "issue_comment",
+            }
+        )
+
+    # Reaction-only signals on agent inline comments.
+    reaction_feedback: list[dict[str, Any]] = []
+    for comment in agent_inline_comments:
+        reactions = comment.get("reactions") or {}
+        if not reactions:
+            continue
+        if not comment.get("in_window"):
+            continue
+        classification = "ambiguous"
+        if int(reactions.get("+1") or 0) > 0 and int(reactions.get("-1") or 0) == 0:
+            classification = "validated"
+        elif int(reactions.get("-1") or 0) > 0 or int(reactions.get("confused") or 0) > 0:
+            classification = "corrected"
+        reaction_feedback.append(
+            {
+                "agent_comment_id": comment.get("id"),
+                "path": comment.get("path"),
+                "html_url": comment.get("html_url"),
+                "reactions": reactions,
+                "classification": classification,
+                "source": "reaction",
+            }
+        )
+
+    return {
+        "number": pr_number,
+        "title": None,
+        "html_url": f"https://github.com/{owner}/{repo}/pull/{pr_number}",
+        "agent_reviews": agent_reviews,
+        "agent_inline_comments": agent_inline_comments,
+        "human_replies": human_replies,
+        "reaction_feedback": reaction_feedback,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    repo_slug = args.repo or _default_repo()
+    if not repo_slug or "/" not in repo_slug:
+        raise SystemExit("Repository slug is required as --repo OWNER/REPO or GITHUB_REPOSITORY.")
+    owner, repo = repo_slug.split("/", 1)
+
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(hours=max(args.since_hours, 1))
+    bot_logins = set(DEFAULT_BOT_LOGINS)
+    bot_logins.update(args.bot_login or [])
+
+    recent_prs = _list_recent_prs(owner, repo, since, args.max_prs)
+    results: list[dict[str, Any]] = []
+    for item in recent_prs:
+        number = item.get("number")
+        if not isinstance(number, int):
+            continue
+        collected = _collect_for_pr(
+            owner,
+            repo,
+            number,
+            since=since,
+            bot_logins=bot_logins,
+        )
+        collected["title"] = item.get("title")
+        # Keep PRs that either had agent activity or human replies in-window.
+        has_agent = bool(collected["agent_reviews"] or collected["agent_inline_comments"])
+        has_human = bool(collected["human_replies"] or collected["reaction_feedback"])
+        if has_agent or has_human:
+            results.append(collected)
+
+    validated = corrected = refined = ambiguous = 0
+    for pr in results:
+        for reply in pr.get("human_replies") or []:
+            label = reply.get("classification")
+            if label == "validated":
+                validated += 1
+            elif label == "corrected":
+                corrected += 1
+            elif label == "refined":
+                refined += 1
+            else:
+                ambiguous += 1
+        for reaction in pr.get("reaction_feedback") or []:
+            label = reaction.get("classification")
+            if label == "validated":
+                validated += 1
+            elif label == "corrected":
+                corrected += 1
+            elif label == "refined":
+                refined += 1
+            else:
+                ambiguous += 1
+
+    corpus = {
+        "repo": repo_slug,
+        "generated_at": now.isoformat(),
+        "since": since.isoformat(),
+        "since_hours": args.since_hours,
+        "bot_logins": sorted(bot_logins),
+        "summary": {
+            "prs_inspected": len(results),
+            "validated": validated,
+            "corrected": corrected,
+            "refined": refined,
+            "ambiguous": ambiguous,
+        },
+        "pull_requests": results,
+    }
+
+    args.output.write_text(json.dumps(corpus, indent=2) + "\n", encoding="utf-8")
+    print(
+        f"wrote {args.output} "
+        f"(prs={len(results)}, validated={validated}, corrected={corrected}, "
+        f"refined={refined}, ambiguous={ambiguous})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: review-pr
+description: Review a pull request diff and write structured feedback to review.json for the workflow to publish. Use when reviewing a checked-out PR from local artifacts like pr_diff.txt and pr_description.txt and producing machine-readable review output instead of posting directly to GitHub.
+---
+
+# Review PR
+
+Review the current pull request and write the output to `review.json`.
+
+This skill is repository-agnostic. It works for any GitHub repository that can supply an annotated PR diff and optional product/tech specs. A separate workflow or apply job is responsible for posting the review to GitHub.
+
+## Context
+
+- The working directory is the PR branch checkout.
+- The workflow usually provides an annotated diff in `pr_diff.txt`.
+- The workflow usually provides the PR description in `pr_description.txt`.
+- If `spec_context.md` exists, it contains product and/or technical specs for implementation-vs-spec validation.
+- When the prompt references `.agents/skills/review-pr/scripts/resolve_spec_context.py`, use that script to materialize `spec_context.md` on demand instead of expecting spec content to be embedded in the prompt.
+- If `pr_diff.txt` is missing but a raw unified diff is available, generate the annotated form with:
+  ```sh
+  python3 .agents/skills/review-pr/scripts/annotate_diff.py --input raw_diff.txt --output pr_diff.txt
+  ```
+- Focus on files and lines changed by this PR.
+- Do not post comments or reviews to GitHub directly.
+
+## Review Scope
+
+- Prioritize correctness, security, error handling, regressions, and meaningful performance issues.
+- Prefer findings grounded in the annotated diff and nearby code in the checkout.
+- When `spec_context.md` exists, compare the implementation against the product and tech commitments in that file. Treat material spec drift as a review concern.
+- If the consuming repository provides a local `check-impl-against-spec` skill, use it when `spec_context.md` exists and fold its findings into the same `review.json`.
+- If the consuming repository provides a local `security-review-pr` companion skill or the prompt requests a security pass, apply it as supplemental guidance and fold any security findings into the same `review.json` rather than emitting a separate output.
+- Include style or nit comments only when you can provide a concrete suggestion block.
+- If a concern involves untouched code, mention it in top-level `body` instead of an inline comment.
+- Only suggest new tests when they exercise a distinct code path or edge case. Do not suggest tests that only vary constructor inputs or struct fields when existing coverage already exercises the meaningful behavior.
+- When a PR is clearly a V0 or initial implementation, frame robustness suggestions such as timeouts, retries, and lifecycle management as optional future work rather than blocking concerns, unless they risk correctness, security, or data loss.
+- For documentation-only or specs-only PRs, focus on clarity, completeness, contradictions, and missing acceptance criteria rather than production-code concerns.
+
+## Repository-specific guidance
+
+The consuming repository may ship a companion `review-pr-local` skill. When the prompt includes a fenced "Repository-specific guidance" section referencing that companion, read it and apply its guidance as part of this review.
+
+Guidance in the companion may never change:
+
+- the output JSON schema
+- the severity labels
+- the safety rules
+- the evidence rules
+- the suggestion-block constraints
+- the annotated-diff line contract
+
+If a companion file is not referenced in the prompt, rely on the core contract alone.
+
+## Diff Line Annotations
+
+The annotated diff uses these prefixes:
+
+- `[OLD:n]` for deleted lines on the old side. Use `"LEFT"`.
+- `[NEW:n]` for added lines on the new side. Use `"RIGHT"`.
+- `[OLD:n,NEW:m]` for unchanged context. Use `"RIGHT"` with line `m`.
+
+Treat these annotations as the only source of truth for inline comment locations. For every inline comment you emit, first identify the exact annotated line in `pr_diff.txt` and copy its path, side, and line number into `review.json`. Do not infer line numbers from prose, rendered GitHub views, file lengths, surrounding spec text, or unannotated snippets. If you cannot point to a specific `[NEW:n]`, `[OLD:n]`, or `[OLD:n,NEW:m]` line in the annotated diff, put the feedback in top-level `body` instead of `comments`.
+
+## Comment Requirements
+
+Every comment body must start with one of these labels:
+
+- `🚨 [CRITICAL]` for bugs, security issues, crashes, or data loss.
+- `⚠️ [IMPORTANT]` for logic problems, edge cases, missing error handling, or material spec drift.
+- `💡 [SUGGESTION]` for worthwhile improvements or better patterns.
+- `🧹 [NIT]` for cleanup only when the comment includes a suggestion block.
+
+Write comments with these constraints:
+
+- Be concise, direct, and actionable.
+- Do not add compliments or hedging.
+- Prefer single-line comments.
+- Keep ranges to at most 10 lines.
+- Restrict inline comments to lines that appear explicitly in the annotated PR diff.
+- Only create file-level or inline comments for files that exist in this PR's diff.
+- If the relevant file or line is not part of the diff, put the feedback in top-level `body` instead of `comments`.
+- Before adding each comment object, verify that its `path`, `side`, `line`, and optional `start_line`/`start_side` correspond to real annotations in the same file's diff section.
+
+## Suggestion Blocks
+
+When proposing a code change, use:
+
+```suggestion
+<replacement code here>
+```
+
+Before recommending a suggestion or claiming a bug, use the local checkout as a real coding agent: apply or otherwise exercise the hypothesized fix and validate it with the repository's available build, typecheck, lint, or targeted tests so the change compiles and does not introduce an obvious new failure. Prefer validated suggestions over speculative ones; if you cannot validate a fix, say so and avoid presenting untested code as ready to accept.
+
+Rules:
+
+- Match the exact indentation of the original file.
+- Include only replacement code.
+- The block content replaces **exactly** the lines `start_line`–`line` inclusive. Every line inside the block becomes the new file content for that range, and GitHub leaves all other lines untouched.
+- Do **not** include lines outside that range. Lines above `start_line` and below `line` remain in the file; repeating them inside the block causes them to appear twice after the suggestion is committed.
+- Never open the block with a line that already appears immediately above `start_line`, and never close the block with a line that already appears immediately below `line`. If you need those lines as anchors, widen `start_line` or `line` so they are actually part of the replaced range.
+- Count brace, bracket, paren, and block-delimiter depth (`{`, `[`, `(`, `end`, etc.) across the original replaced lines and ensure the replacement ends at the same depth. Do not emit phantom closing tokens, and do not drop required ones.
+- When unsure of the surrounding context, widen `start_line`/`line` to include enough real lines from the diff rather than guessing at surrounding tokens.
+- For multi-line suggestions, set `start_line` and `start_side` to the first line, and `line` and `side` to the last line.
+
+## Spec Alignment
+
+When `spec_context.md` exists:
+
+1. Extract concrete commitments: required behaviors, constraints, affected areas, validation steps, and non-goals.
+2. Compare those commitments against `pr_diff.txt` and the checked-out branch.
+3. Flag material mismatches only. Harmless differences in naming, structure, or low-level technique are acceptable when they preserve the intended outcome.
+4. Put broad drift in top-level `body`. Add inline comments only when the mismatch can be tied to changed lines.
+5. Treat material drift as at least an important concern.
+6. If the implementation matches the specs closely enough, do not add comments just to mention alignment.
+
+If no useful spec context is available, review the PR on its own merits and note the missing specs only when that absence materially increases risk.
+
+## Output Format
+
+Create `review.json` with this shape:
+
+```json
+{
+  "verdict": "REJECT",
+  "body": "## Overview\n...\n\n## Concerns\n- ...\n\n## Verdict\nFound: 1 critical, 2 important, 3 suggestions\n\n**Request changes**",
+  "comments": [
+    {
+      "path": "path/to/file",
+      "line": 42,
+      "side": "RIGHT",
+      "start_line": 40,
+      "start_side": "RIGHT",
+      "body": "⚠️ [IMPORTANT] Short explanation\n\n```suggestion\nreplacement\n```"
+    }
+  ]
+}
+```
+
+Field rules:
+
+- `verdict` is required and must be exactly the string `"APPROVE"` or `"REJECT"` (uppercase). Map your final recommendation as: `Approve` or `Approve with nits` → `"APPROVE"`; `Request changes` → `"REJECT"`. The `verdict` and the human-readable recommendation in top-level `body` must agree.
+- Top-level `body` is the GitHub review body and is required. Use `body`, not `summary`, for the review overview and final recommendation.
+- `comments` is required and must be an array. Use an empty array when there are no inline comments.
+- `path` must be relative to the repository root.
+- `line` is required and must target the correct side.
+- `start_line` is optional and only for multi-line ranges. When `start_line` is present, `start_side` is required and must be `"LEFT"` or `"RIGHT"`.
+- `side` must be `"LEFT"` or `"RIGHT"`.
+
+## Body Requirements
+
+The top-level `body` must include:
+
+- A high-level overview of the PR.
+- Important concerns and any untouched-code concerns that could not be commented inline.
+- Issue counts in the format `Found: X critical, Y important, Z suggestions`.
+- A final recommendation of `Approve`, `Approve with nits`, or `Request changes`. This recommendation must match the top-level `verdict` field (`Approve` / `Approve with nits` → `"APPROVE"`; `Request changes` → `"REJECT"`).
+
+## Final Checks
+
+Before returning or uploading `review.json`:
+
+- Fix invalid JSON if validation fails.
+- Confirm line numbers match the annotated diff.
+- Run the bundled validator against the exact annotated diff you reviewed:
+  ```sh
+  python3 .agents/skills/review-pr/scripts/validate_review_json.py --review-json review.json --diff pr_diff.txt
+  ```
+  If the script reports any invalid comments, fix `review.json` and rerun it. Do not return or upload `review.json` until this validator passes. If the script path is not present at that exact location, locate `validate_review_json.py` under the loaded `review-pr` skill directory and run that copy with the same arguments.
+- Do not run `gh pr review`, `gh pr comment`, `gh api`, or any other command that posts to GitHub.
+
+Your only output is the final `review.json`.

--- a/.agents/skills/review-pr/scripts/annotate_diff.py
+++ b/.agents/skills/review-pr/scripts/annotate_diff.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Annotate a unified git/GitHub patch with review line markers.
+
+The review-pr skill and validator expect lines like:
+
+  [OLD:12] removed line
+  [NEW:34] added line
+  [OLD:12,NEW:34] context line
+
+This script converts a normal unified diff into that form so any
+repository can prepare `pr_diff.txt` without host-specific tooling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+HUNK_HEADER_PATTERN = re.compile(
+    r"^@@ -(?P<old_start>\d+)(?:,(?P<old_count>\d+))? "
+    r"\+(?P<new_start>\d+)(?:,(?P<new_count>\d+))? @@"
+)
+
+
+def annotate_patch(patch: str) -> str:
+    lines: list[str] = []
+    old_line: int | None = None
+    new_line: int | None = None
+
+    for raw_line in patch.splitlines():
+        # Full multi-file `git diff` output starts each file with `diff --git`.
+        # Reset hunk counters there so later `---` / `+++` headers pass through
+        # the not-in-hunk branch instead of being treated as deleted/added lines.
+        # Do not special-case `---` / `+++` themselves: a deleted content line
+        # whose text begins with `-- ` is also written as `--- ...` in unified
+        # diffs and must still be annotated as hunk content when inside a hunk.
+        if raw_line.startswith("diff --git ") or raw_line.startswith("Binary files "):
+            old_line = None
+            new_line = None
+            lines.append(raw_line)
+            continue
+
+        header_match = HUNK_HEADER_PATTERN.match(raw_line)
+        if header_match:
+            old_line = int(header_match.group("old_start"))
+            new_line = int(header_match.group("new_start"))
+            lines.append(raw_line)
+            continue
+        if old_line is None or new_line is None or raw_line.startswith("\\"):
+            lines.append(raw_line)
+            continue
+
+        marker = raw_line[:1]
+        text = raw_line[1:]
+        if marker == "-":
+            lines.append(f"[OLD:{old_line}] {text}")
+            old_line += 1
+        elif marker == "+":
+            lines.append(f"[NEW:{new_line}] {text}")
+            new_line += 1
+        elif marker == " ":
+            lines.append(f"[OLD:{old_line},NEW:{new_line}] {text}")
+            old_line += 1
+            new_line += 1
+        else:
+            lines.append(raw_line)
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Annotate a unified diff for review-pr comment placement."
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        help="Path to a unified diff. Reads stdin when omitted.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Path to write the annotated diff. Writes stdout when omitted.",
+    )
+    args = parser.parse_args()
+
+    if args.input is None:
+        patch = sys.stdin.read()
+    else:
+        try:
+            patch = args.input.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            print(f"annotate_diff failed: {args.input} does not exist", file=sys.stderr)
+            return 1
+
+    annotated = annotate_patch(patch)
+    if not annotated.endswith("\n"):
+        annotated += "\n"
+
+    if args.output is None:
+        sys.stdout.write(annotated)
+    else:
+        args.output.write_text(annotated, encoding="utf-8")
+        print(f"wrote annotated diff to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/review-pr/scripts/publish_review.py
+++ b/.agents/skills/review-pr/scripts/publish_review.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Publish a validated review.json artifact as a GitHub pull request review.
+
+This script is intended for the deterministic apply job in Cloud Factory's
+review workflow. It never invents findings: it only posts the agent-authored
+review after optional validation against the annotated diff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ALLOWED_VERDICTS = {"APPROVE", "REJECT"}
+POWERED_BY_SUFFIX = "\n\n---\n_Powered by [Oz](https://warp.dev/oz)_\n"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Publish review.json as a GitHub pull request review."
+    )
+    parser.add_argument(
+        "--review-json",
+        type=Path,
+        default=Path("review.json"),
+        help="Path to the review.json artifact.",
+    )
+    parser.add_argument(
+        "--diff",
+        type=Path,
+        default=Path("pr_diff.txt"),
+        help="Optional annotated diff used for validation before publish.",
+    )
+    parser.add_argument(
+        "--repo",
+        help="Repository slug OWNER/REPO. Defaults to GITHUB_REPOSITORY.",
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        help="Pull request number. Defaults to GitHub Actions context when available.",
+    )
+    parser.add_argument(
+        "--skip-validation",
+        action="store_true",
+        help="Skip running validate_review_json.py before publishing.",
+    )
+    parser.add_argument(
+        "--event",
+        choices=("auto", "APPROVE", "REQUEST_CHANGES", "COMMENT"),
+        default="auto",
+        help=(
+            "GitHub review event. 'auto' maps APPROVE->APPROVE and REJECT->REQUEST_CHANGES."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SystemExit(f"publish failed: {path} does not exist") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"publish failed: {path} is invalid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SystemExit(f"publish failed: {path} must contain a JSON object")
+    return payload
+
+
+def _default_repo() -> str | None:
+    return (os.environ.get("GITHUB_REPOSITORY") or "").strip() or None
+
+
+def _default_pr_number() -> int | None:
+    event_path = (os.environ.get("GITHUB_EVENT_PATH") or "").strip()
+    if event_path:
+        try:
+            event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            event = None
+        if isinstance(event, dict):
+            for key in ("pull_request", "issue"):
+                number = (event.get(key) or {}).get("number")
+                if isinstance(number, int):
+                    return number
+    ref = (os.environ.get("GITHUB_REF") or "").strip()
+    if ref.startswith("refs/pull/"):
+        parts = ref.split("/")
+        if len(parts) >= 3 and parts[2].isdigit():
+            return int(parts[2])
+    return None
+
+
+def _validate(review_json: Path, diff: Path) -> None:
+    script = Path(__file__).with_name("validate_review_json.py")
+    if not script.is_file():
+        raise SystemExit(f"publish failed: validator not found at {script}")
+    if not diff.is_file():
+        raise SystemExit(f"publish failed: annotated diff not found at {diff}")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--review-json",
+            str(review_json),
+            "--diff",
+            str(diff),
+        ],
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit("publish failed: review.json failed validation")
+
+
+def _normalize_comments(raw_comments: Any) -> list[dict[str, Any]]:
+    if raw_comments is None:
+        return []
+    if not isinstance(raw_comments, list):
+        raise SystemExit("publish failed: comments must be a list")
+
+    comments: list[dict[str, Any]] = []
+    for index, item in enumerate(raw_comments):
+        if not isinstance(item, dict):
+            raise SystemExit(f"publish failed: comments[{index}] must be an object")
+        path = str(item.get("path") or "").strip()
+        body = str(item.get("body") or "").strip()
+        side = str(item.get("side") or "").strip().upper()
+        line = item.get("line")
+        if not path or not body or side not in {"LEFT", "RIGHT"} or not isinstance(line, int):
+            raise SystemExit(
+                f"publish failed: comments[{index}] is missing required path/line/side/body"
+            )
+        comment: dict[str, Any] = {
+            "path": path,
+            "line": line,
+            "side": side,
+            "body": body,
+        }
+        if item.get("start_line") is not None:
+            start_line = item.get("start_line")
+            start_side = str(item.get("start_side") or "").strip().upper()
+            if not isinstance(start_line, int) or start_side not in {"LEFT", "RIGHT"}:
+                raise SystemExit(
+                    f"publish failed: comments[{index}] has invalid start_line/start_side"
+                )
+            comment["start_line"] = start_line
+            comment["start_side"] = start_side
+        comments.append(comment)
+    return comments
+
+
+def _event_for_verdict(verdict: str, requested: str) -> str:
+    if requested != "auto":
+        return requested
+    return "APPROVE" if verdict == "APPROVE" else "REQUEST_CHANGES"
+
+
+def main() -> int:
+    args = _parse_args()
+    repo = args.repo or _default_repo()
+    pr_number = args.pr or _default_pr_number()
+    if not repo or "/" not in repo:
+        raise SystemExit("publish failed: --repo OWNER/REPO or GITHUB_REPOSITORY is required")
+    if not pr_number:
+        raise SystemExit("publish failed: --pr N or GitHub Actions PR context is required")
+
+    if not args.skip_validation:
+        _validate(args.review_json, args.diff)
+
+    review = _load_json(args.review_json)
+    verdict = str(review.get("verdict") or "").strip().upper()
+    if verdict not in ALLOWED_VERDICTS:
+        raise SystemExit('publish failed: verdict must be "APPROVE" or "REJECT"')
+
+    body = review.get("body")
+    if body is None:
+        body = review.get("summary")
+    if not isinstance(body, str) or not body.strip():
+        raise SystemExit("publish failed: review body is required")
+
+    comments = _normalize_comments(review.get("comments"))
+    event = _event_for_verdict(verdict, args.event)
+
+    body_text = body.strip()
+    if "warp.dev/oz" not in body_text.lower():
+        body_text = body_text + POWERED_BY_SUFFIX
+
+    payload = {
+        "body": body_text,
+        "event": event,
+        "comments": comments,
+    }
+
+    payload_path = Path("review_publish_payload.json")
+
+    env = os.environ.copy()
+    if "GH_TOKEN" not in env and "GITHUB_TOKEN" in env:
+        env["GH_TOKEN"] = env["GITHUB_TOKEN"]
+
+    def post_review(event_name: str) -> subprocess.CompletedProcess[str]:
+        payload["event"] = event_name
+        payload_path.write_text(json.dumps(payload), encoding="utf-8")
+        return subprocess.run(
+            [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                f"repos/{repo}/pulls/{pr_number}/reviews",
+                "--input",
+                str(payload_path),
+            ],
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    try:
+        result = post_review(event)
+        published_event = event
+
+        # Many repositories leave the default Actions setting that blocks
+        # GITHUB_TOKEN from approving pull requests. In that case still publish the
+        # review body and inline comments as a plain COMMENT so the factory does not
+        # fail after a successful agent review.
+        if result.returncode != 0 and event == "APPROVE":
+            combined = f"{result.stdout}\n{result.stderr}".lower()
+            if (
+                "not permitted to approve" in combined
+                or "can not approve" in combined
+                or "cannot approve" in combined
+            ):
+                print(
+                    "APPROVE is not permitted for this token; falling back to COMMENT",
+                    file=sys.stderr,
+                )
+                result = post_review("COMMENT")
+                published_event = "COMMENT"
+
+        if result.returncode != 0:
+            sys.stderr.write(result.stdout)
+            sys.stderr.write(result.stderr)
+            raise SystemExit("publish failed: gh api request failed")
+
+        print(
+            f"published review for {repo}#{pr_number}: "
+            f"event={published_event}, comments={len(comments)}, verdict={verdict}"
+        )
+        return 0
+    finally:
+        try:
+            payload_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/review-pr/scripts/resolve_spec_context.py
+++ b/.agents/skills/review-pr/scripts/resolve_spec_context.py
@@ -1,0 +1,763 @@
+#!/usr/bin/env python3
+"""Resolve product and tech spec context for a pull request.
+
+Designed for Cloud Factory and other generic repositories that keep specs as:
+
+  specs/<issue-slug>/PRODUCT.md
+  specs/<issue-slug>/TECH.md
+
+It prefers local checkout files, then falls back to the GitHub API when a token
+is available. Unlike Warp-specific resolvers, it does not require plan-approved
+labels, GH-prefixed issue directories, or oz-agent branch naming.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+API_ROOT = "https://api.github.com"
+GRAPHQL_ROOT = f"{API_ROOT}/graphql"
+NO_SPEC_CONTEXT_MESSAGE = "No approved or repository spec context was found for this PR."
+REPO_ROOT = Path(
+    (os.environ.get("OZ_REPO_ROOT") or os.environ.get("GITHUB_WORKSPACE") or "").strip()
+    or Path(__file__).resolve().parents[4]
+)
+
+_CLOSING_ISSUES_QUERY = (
+    "query($owner: String!, $name: String!, $number: Int!, $after: String) {"
+    " repository(owner: $owner, name: $name) {"
+    " pullRequest(number: $number) {"
+    " closingIssuesReferences(first: 100, after: $after) {"
+    " pageInfo { hasNextPage endCursor }"
+    " nodes {"
+    " number"
+    " repository { owner { login } name }"
+    " }"
+    " }"
+    " }"
+    " }"
+    " }"
+)
+
+_MANUAL_LINKED_ISSUES_QUERY = (
+    "query($owner: String!, $name: String!, $number: Int!, $after: String) {"
+    " repository(owner: $owner, name: $name) {"
+    " pullRequest(number: $number) {"
+    " timelineItems(first: 100, after: $after, itemTypes: [CONNECTED_EVENT, DISCONNECTED_EVENT]) {"
+    " pageInfo { hasNextPage endCursor }"
+    " nodes {"
+    " __typename"
+    " ... on ConnectedEvent {"
+    " subject {"
+    " __typename"
+    " ... on Issue {"
+    " number"
+    " repository { owner { login } name }"
+    " }"
+    " }"
+    " }"
+    " ... on DisconnectedEvent {"
+    " subject {"
+    " __typename"
+    " ... on Issue {"
+    " number"
+    " repository { owner { login } name }"
+    " }"
+    " }"
+    " }"
+    " }"
+    " }"
+    " }"
+    " }"
+    " }"
+)
+
+ISSUE_REF_PATTERN = re.compile(
+    r"(?:(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+)?#(\d+)",
+    re.IGNORECASE,
+)
+BRANCH_ISSUE_PATTERN = re.compile(
+    r"(?:^|/)(?:spec|implement|feature|fix|issue)[-/]?(\d+)(?:$|[/-])",
+    re.IGNORECASE,
+)
+SPEC_DIR_ISSUE_PATTERN = re.compile(r"^specs/[^/]*?(?:issue[-_])?(\d+)[^/]*/", re.IGNORECASE)
+SPEC_FILENAMES = ("PRODUCT.md", "TECH.md", "product.md", "tech.md")
+
+
+def _resolve_token() -> str | None:
+    token = (os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or "").strip()
+    return token or None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Resolve product/tech spec context for a pull request."
+    )
+    parser.add_argument(
+        "--repo",
+        help="Repository slug in OWNER/REPO format. Defaults to GITHUB_REPOSITORY.",
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        help="Pull request number. Defaults to the number extracted from GITHUB_REF.",
+    )
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=REPO_ROOT,
+        help="Local checkout root used to discover checked-in specs.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the rendered markdown. Prints to stdout by default.",
+    )
+    return parser.parse_args()
+
+
+def _gh_request(
+    path_or_url: str,
+    *,
+    token: str,
+    accept: str = "application/vnd.github+json",
+    params: dict[str, str] | None = None,
+    method: str = "GET",
+    payload: bytes | None = None,
+    allow_http_error: bool = False,
+) -> tuple[int, bytes, dict[str, str]]:
+    url = path_or_url if path_or_url.startswith("https://") else f"{API_ROOT}{path_or_url}"
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+    request = urllib.request.Request(url, data=payload, method=method)  # noqa: S310
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Accept", accept)
+    request.add_header("X-GitHub-Api-Version", "2022-11-28")
+    request.add_header("User-Agent", "cloud-factory-resolve-spec-context")
+    if payload is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request) as response:  # noqa: S310
+            return response.status, response.read(), dict(response.headers)
+    except urllib.error.HTTPError as exc:
+        body = exc.read() if exc.fp is not None else b""
+        if allow_http_error:
+            return exc.code, body, dict(exc.headers or {})
+        detail = body.decode("utf-8", errors="replace")[:500]
+        raise SystemExit(
+            f"GitHub API request failed ({exc.code}) for {path_or_url}: {detail}"
+        ) from exc
+
+
+def _gh_json(
+    path: str,
+    *,
+    token: str,
+    params: dict[str, str] | None = None,
+    allow_http_error: bool = False,
+) -> tuple[int, Any]:
+    status, body, _headers = _gh_request(
+        path,
+        token=token,
+        params=params,
+        allow_http_error=allow_http_error,
+    )
+    return status, json.loads(body.decode("utf-8"))
+
+
+def _parse_next_link(link_header: str) -> str | None:
+    if not link_header:
+        return None
+    for piece in link_header.split(","):
+        segment = piece.strip()
+        if not segment.startswith("<"):
+            continue
+        end = segment.find(">")
+        if end == -1:
+            continue
+        url = segment[1:end]
+        rel_part = segment[end + 1 :]
+        if 'rel="next"' not in rel_part:
+            continue
+        parsed = urllib.parse.urlparse(url)
+        return parsed.path + (f"?{parsed.query}" if parsed.query else "")
+    return None
+
+
+def _gh_paginated_json(
+    path: str,
+    *,
+    token: str,
+    params: dict[str, str] | None = None,
+    per_page: int = 100,
+) -> list[Any]:
+    merged_params = dict(params or {})
+    merged_params.setdefault("per_page", str(per_page))
+    next_path: str | None = (
+        f"{path}?{urllib.parse.urlencode(merged_params)}" if merged_params else path
+    )
+    items: list[Any] = []
+    while next_path:
+        status, body, headers = _gh_request(next_path, token=token)
+        if status != 200:
+            raise SystemExit(f"GitHub API returned status {status} for {next_path}")
+        page = json.loads(body.decode("utf-8"))
+        if not isinstance(page, list):
+            raise SystemExit(
+                f"Expected JSON array from {next_path}, got {type(page).__name__}."
+            )
+        items.extend(page)
+        next_path = _parse_next_link(headers.get("Link") or headers.get("link") or "")
+    return items
+
+
+def _gh_graphql_json(query: str, variables: dict[str, Any], *, token: str) -> dict[str, Any]:
+    payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+    _status, body, _headers = _gh_request(
+        GRAPHQL_ROOT,
+        token=token,
+        accept="application/json",
+        method="POST",
+        payload=payload,
+    )
+    data = json.loads(body.decode("utf-8"))
+    errors = data.get("errors") or []
+    if errors:
+        raise SystemExit(f"GitHub GraphQL request failed: {errors}")
+    return data
+
+
+def _normalize_github_linked_issue(node: Any, *, source: str) -> dict[str, Any] | None:
+    if not isinstance(node, dict):
+        return None
+    number = node.get("number")
+    if not isinstance(number, int):
+        return None
+    repository = node.get("repository") or {}
+    owner = ((repository.get("owner") or {}).get("login") or "").strip()
+    repo = str(repository.get("name") or "").strip()
+    if not owner or not repo:
+        return None
+    return {
+        "owner": owner,
+        "repo": repo,
+        "number": number,
+        "source": source,
+    }
+
+
+def _graphql_pull_request_data(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    query: str,
+    *,
+    token: str,
+    after: str | None,
+) -> dict[str, Any]:
+    data = _gh_graphql_json(
+        query,
+        {
+            "owner": owner,
+            "name": repo,
+            "number": int(pr_number),
+            "after": after,
+        },
+        token=token,
+    )
+    return (((data.get("data") or {}).get("repository") or {}).get("pullRequest") or {})
+
+
+def _fetch_closing_issue_references(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    *,
+    token: str,
+) -> list[dict[str, Any]]:
+    linked: dict[tuple[str, str, int, str], dict[str, Any]] = {}
+    cursor: str | None = None
+    while True:
+        pr_data = _graphql_pull_request_data(
+            owner,
+            repo,
+            pr_number,
+            _CLOSING_ISSUES_QUERY,
+            token=token,
+            after=cursor,
+        )
+        closing_refs = pr_data.get("closingIssuesReferences") or {}
+        for node in closing_refs.get("nodes") or []:
+            issue_ref = _normalize_github_linked_issue(
+                node,
+                source="closingIssuesReferences",
+            )
+            if issue_ref is None:
+                continue
+            key = (
+                issue_ref["owner"].lower(),
+                issue_ref["repo"].lower(),
+                int(issue_ref["number"]),
+                str(issue_ref["source"]),
+            )
+            linked[key] = issue_ref
+        page_info = closing_refs.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            break
+    return list(linked.values())
+
+
+def _fetch_manual_linked_issue_references(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    *,
+    token: str,
+) -> list[dict[str, Any]]:
+    connected: dict[tuple[str, str, int], dict[str, Any]] = {}
+    cursor: str | None = None
+    while True:
+        pr_data = _graphql_pull_request_data(
+            owner,
+            repo,
+            pr_number,
+            _MANUAL_LINKED_ISSUES_QUERY,
+            token=token,
+            after=cursor,
+        )
+        timeline_items = pr_data.get("timelineItems") or {}
+        for node in timeline_items.get("nodes") or []:
+            if not isinstance(node, dict):
+                continue
+            issue_ref = _normalize_github_linked_issue(
+                node.get("subject"),
+                source="manualLink",
+            )
+            if issue_ref is None:
+                continue
+            key = (
+                issue_ref["owner"].lower(),
+                issue_ref["repo"].lower(),
+                int(issue_ref["number"]),
+            )
+            typename = str(node.get("__typename") or "")
+            if typename == "ConnectedEvent":
+                connected[key] = issue_ref
+            elif typename == "DisconnectedEvent":
+                connected.pop(key, None)
+        page_info = timeline_items.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            break
+    return list(connected.values())
+
+
+def _dedupe_ints(values: list[int]) -> list[int]:
+    return list(dict.fromkeys(int(value) for value in values))
+
+
+def _same_repo_issue_numbers(
+    owner: str,
+    repo: str,
+    issue_refs: list[dict[str, Any]],
+) -> list[int]:
+    normalized_owner = owner.lower()
+    normalized_repo = repo.lower()
+    return _dedupe_ints(
+        [
+            int(issue_ref["number"])
+            for issue_ref in issue_refs
+            if str(issue_ref.get("owner") or "").lower() == normalized_owner
+            and str(issue_ref.get("repo") or "").lower() == normalized_repo
+        ]
+    )
+
+
+def _issue_numbers_from_text(text: str) -> list[int]:
+    return _dedupe_ints([int(match.group(1)) for match in ISSUE_REF_PATTERN.finditer(text or "")])
+
+
+def _issue_numbers_from_branch(head_ref: str) -> list[int]:
+    return _dedupe_ints(
+        [int(match.group(1)) for match in BRANCH_ISSUE_PATTERN.finditer(head_ref or "")]
+    )
+
+
+def _issue_numbers_from_changed_files(changed_files: list[str]) -> list[int]:
+    return _dedupe_ints(
+        [
+            int(match.group(1))
+            for filename in changed_files
+            for match in [SPEC_DIR_ISSUE_PATTERN.match(filename)]
+            if match
+        ]
+    )
+
+
+def _fetch_pull(owner: str, repo: str, pr_number: int, *, token: str) -> dict[str, Any]:
+    _status, payload = _gh_json(f"/repos/{owner}/{repo}/pulls/{pr_number}", token=token)
+    if not isinstance(payload, dict):
+        raise SystemExit(
+            f"Expected object payload for pull request #{pr_number}, got {type(payload).__name__}."
+        )
+    return payload
+
+
+def _fetch_pull_files(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    *,
+    token: str,
+) -> list[dict[str, Any]]:
+    files = _gh_paginated_json(
+        f"/repos/{owner}/{repo}/pulls/{pr_number}/files",
+        token=token,
+    )
+    return [item for item in files if isinstance(item, dict)]
+
+
+def _fetch_file_contents(
+    owner: str,
+    repo: str,
+    path: str,
+    *,
+    ref: str,
+    token: str,
+) -> str | None:
+    encoded_path = urllib.parse.quote(path, safe="/")
+    status, payload = _gh_json(
+        f"/repos/{owner}/{repo}/contents/{encoded_path}",
+        token=token,
+        params={"ref": ref},
+        allow_http_error=True,
+    )
+    if status == 404:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    content = str(payload.get("content") or "").strip()
+    encoding = str(payload.get("encoding") or "").strip().lower()
+    if not content or encoding != "base64":
+        return None
+    return base64.b64decode(content.encode("utf-8")).decode("utf-8").strip()
+
+
+def _local_spec_entries_for_issue(workspace: Path, issue_number: int) -> list[dict[str, str]]:
+    specs_root = workspace / "specs"
+    if not specs_root.is_dir():
+        return []
+
+    candidates: list[Path] = []
+    for path in sorted(specs_root.iterdir()):
+        if not path.is_dir():
+            continue
+        name = path.name.lower()
+        if (
+            re.search(rf"(?:^|[-_])(?:issue[-_]?)?{issue_number}(?:$|[-_])", name)
+            or name.endswith(str(issue_number))
+            or name.startswith(f"github-{issue_number}")
+            or name.startswith(f"gh{issue_number}")
+            or name.startswith(f"gh-{issue_number}")
+        ):
+            candidates.append(path)
+
+    entries: list[dict[str, str]] = []
+    for directory in candidates:
+        found_for_dir: dict[str, dict[str, str]] = {}
+        for filename in SPEC_FILENAMES:
+            file_path = directory / filename
+            if not file_path.is_file():
+                continue
+            kind = "PRODUCT.md" if filename.lower().startswith("product") else "TECH.md"
+            rel_path = str(file_path.relative_to(workspace))
+            found_for_dir[kind] = {
+                "path": rel_path,
+                "content": file_path.read_text(encoding="utf-8").strip(),
+            }
+        for kind in ("PRODUCT.md", "TECH.md"):
+            if kind in found_for_dir:
+                entries.append(found_for_dir[kind])
+    return entries
+
+
+def _remote_spec_entries_for_issue(
+    owner: str,
+    repo: str,
+    issue_number: int,
+    *,
+    ref: str,
+    token: str,
+) -> list[dict[str, str]]:
+    status, payload = _gh_json(
+        f"/repos/{owner}/{repo}/contents/specs",
+        token=token,
+        params={"ref": ref},
+        allow_http_error=True,
+    )
+    if status == 404 or not isinstance(payload, list):
+        return []
+
+    entries: list[dict[str, str]] = []
+    for item in payload:
+        if not isinstance(item, dict) or item.get("type") != "dir":
+            continue
+        name = str(item.get("name") or "")
+        lowered = name.lower()
+        if not (
+            re.search(rf"(?:^|[-_])(?:issue[-_]?)?{issue_number}(?:$|[-_])", lowered)
+            or lowered.endswith(str(issue_number))
+            or lowered.startswith(f"github-{issue_number}")
+            or lowered.startswith(f"gh{issue_number}")
+            or lowered.startswith(f"gh-{issue_number}")
+        ):
+            continue
+        for filename in ("PRODUCT.md", "TECH.md"):
+            path = f"specs/{name}/{filename}"
+            content = _fetch_file_contents(owner, repo, path, ref=ref, token=token)
+            if content:
+                entries.append({"path": path, "content": content})
+    return entries
+
+
+def _local_spec_entries_from_changed_files(
+    workspace: Path,
+    changed_files: list[str],
+) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for filename in changed_files:
+        if not re.search(r"(?i)^specs/.+/(product|tech)\.md$", filename):
+            continue
+        path = workspace / filename
+        if not path.is_file() or filename in seen:
+            continue
+        seen.add(filename)
+        entries.append(
+            {
+                "path": filename,
+                "content": path.read_text(encoding="utf-8").strip(),
+            }
+        )
+    return entries
+
+
+def resolve_issue_number_for_pr(
+    owner: str,
+    repo: str,
+    pr: dict[str, Any],
+    changed_files: list[str],
+    *,
+    token: str | None,
+) -> int | None:
+    head_ref = str(((pr.get("head") or {}).get("ref")) or "")
+    body = str(pr.get("body") or "")
+    title = str(pr.get("title") or "")
+
+    candidates = _dedupe_ints(
+        _issue_numbers_from_branch(head_ref)
+        + _issue_numbers_from_changed_files(changed_files)
+        + _issue_numbers_from_text(f"{title}\n{body}")
+    )
+
+    linked: list[dict[str, Any]] = []
+    if token:
+        linked = _fetch_closing_issue_references(owner, repo, int(pr["number"]), token=token)
+        linked.extend(
+            _fetch_manual_linked_issue_references(owner, repo, int(pr["number"]), token=token)
+        )
+        candidates = _dedupe_ints(candidates + _same_repo_issue_numbers(owner, repo, linked))
+
+    if len(candidates) == 1:
+        return candidates[0]
+    if not candidates:
+        return None
+
+    # Prefer the most specific sources: branch naming and linked issues over free text.
+    preferred = _dedupe_ints(
+        _issue_numbers_from_branch(head_ref) + _issue_numbers_from_changed_files(changed_files)
+    )
+    if token:
+        preferred = _dedupe_ints(preferred + _same_repo_issue_numbers(owner, repo, linked))
+    if len(preferred) == 1:
+        return preferred[0]
+    return None
+
+
+def resolve_spec_context_for_pr(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    *,
+    workspace: Path,
+    token: str | None,
+) -> dict[str, Any]:
+    if token is None:
+        # Local-only fallback: inspect the checkout for specs related to the PR number
+        # or any obvious issue-linked directories.
+        changed_files: list[str] = []
+        local_from_pr_number = _local_spec_entries_for_issue(workspace, pr_number)
+        if local_from_pr_number:
+            return {
+                "issue_number": pr_number,
+                "spec_context_source": "directory",
+                "spec_entries": local_from_pr_number,
+                "changed_files": changed_files,
+            }
+        return {
+            "issue_number": None,
+            "spec_context_source": "",
+            "spec_entries": [],
+            "changed_files": changed_files,
+        }
+
+    pr = _fetch_pull(owner, repo, pr_number, token=token)
+    files = _fetch_pull_files(owner, repo, pr_number, token=token)
+    changed_files = [str(file.get("filename") or "") for file in files]
+    head_ref = str(((pr.get("head") or {}).get("ref")) or "HEAD")
+
+    issue_number = resolve_issue_number_for_pr(
+        owner,
+        repo,
+        pr,
+        changed_files,
+        token=token,
+    )
+
+    spec_entries: list[dict[str, str]] = []
+    source = ""
+
+    if issue_number is not None:
+        local_entries = _local_spec_entries_for_issue(workspace, issue_number)
+        if local_entries:
+            spec_entries = local_entries
+            source = "directory"
+        else:
+            remote_entries = _remote_spec_entries_for_issue(
+                owner,
+                repo,
+                issue_number,
+                ref=head_ref,
+                token=token,
+            )
+            if remote_entries:
+                spec_entries = remote_entries
+                source = "directory"
+
+    if not spec_entries:
+        # Specs-only PRs may change PRODUCT.md/TECH.md directly.
+        local_from_diff = _local_spec_entries_from_changed_files(workspace, changed_files)
+        if local_from_diff:
+            spec_entries = local_from_diff
+            source = "directory"
+        else:
+            for filename in changed_files:
+                if not re.search(r"(?i)^specs/.+/(product|tech)\.md$", filename):
+                    continue
+                content = _fetch_file_contents(
+                    owner,
+                    repo,
+                    filename,
+                    ref=head_ref,
+                    token=token,
+                )
+                if content:
+                    spec_entries.append({"path": filename, "content": content})
+                    source = "directory"
+
+    return {
+        "issue_number": issue_number,
+        "spec_context_source": source,
+        "spec_entries": spec_entries,
+        "changed_files": changed_files,
+    }
+
+
+def _format_spec_context(spec_context: dict[str, Any]) -> str:
+    sections: list[str] = []
+    source = str(spec_context.get("spec_context_source") or "")
+    issue_number = spec_context.get("issue_number")
+    if source == "directory" and issue_number:
+        sections.append(
+            f"Repository spec context was found in `specs/` for issue #{int(issue_number)}."
+        )
+    elif source == "directory":
+        sections.append("Repository spec context was found in `specs/`.")
+    for entry in spec_context.get("spec_entries") or []:
+        if not isinstance(entry, dict):
+            continue
+        path = str(entry.get("path") or "").strip()
+        content = str(entry.get("content") or "").strip()
+        if not path or not content:
+            continue
+        sections.append(f"## {path}\n\n{content}")
+    return "\n\n".join(sections).strip() or NO_SPEC_CONTEXT_MESSAGE
+
+
+def _default_repo() -> str | None:
+    return (os.environ.get("GITHUB_REPOSITORY") or "").strip() or None
+
+
+def _default_pr_number() -> int | None:
+    ref = (os.environ.get("GITHUB_REF") or "").strip()
+    match = re.match(r"refs/pull/(\d+)/", ref)
+    if match:
+        return int(match.group(1))
+    event_path = (os.environ.get("GITHUB_EVENT_PATH") or "").strip()
+    if not event_path:
+        return None
+    try:
+        event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    for key in ("pull_request", "issue"):
+        number = ((event.get(key) or {}) if isinstance(event, dict) else {}).get("number")
+        if isinstance(number, int):
+            return number
+    return None
+
+
+def main() -> None:
+    args = _parse_args()
+    repo_slug = args.repo or _default_repo()
+    pr_number = args.pr or _default_pr_number()
+    if not repo_slug or "/" not in repo_slug:
+        raise SystemExit(
+            "Repository slug is required as --repo OWNER/REPO or GITHUB_REPOSITORY."
+        )
+    if not pr_number:
+        raise SystemExit("Pull request number is required as --pr N or from GitHub Actions context.")
+
+    owner, repo = repo_slug.split("/", 1)
+    spec_context = resolve_spec_context_for_pr(
+        owner,
+        repo,
+        pr_number,
+        workspace=args.workspace,
+        token=_resolve_token(),
+    )
+    rendered = _format_spec_context(spec_context)
+    if args.output is not None:
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+        print(f"wrote spec context to {args.output}")
+    else:
+        print(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/review-pr/scripts/validate_review_json.py
+++ b/.agents/skills/review-pr/scripts/validate_review_json.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Validate a review.json artifact against an annotated PR diff.
+
+This script is packaged with the review-pr skill and must work when the skill
+is copied into a consuming repository without the full oz-for-oss source tree.
+Keep it self-contained: do not import helpers from the repository package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TypedDict
+
+
+class ReviewComment(TypedDict, total=False):
+    """Normalized review comment accepted by GitHub's create-review API."""
+
+    path: str
+    line: int
+    side: str
+    body: str
+    start_line: int
+    start_side: str
+
+
+@dataclass(frozen=True)
+class ReviewValidationResult:
+    """Validated review fields plus any comment-location errors."""
+
+    body: str
+    comments: list[ReviewComment]
+    errors: list[str]
+
+
+SUGGESTION_BLOCK_PATTERN = re.compile(
+    r"```suggestion[^\n]*\r?\n(?P<content>.*?)\r?\n```",
+    re.DOTALL,
+)
+ANNOTATED_OLD_PATTERN = re.compile(r"^\[OLD:(?P<old>\d+)\] ?(?P<text>.*)$")
+ANNOTATED_NEW_PATTERN = re.compile(r"^\[NEW:(?P<new>\d+)\] ?(?P<text>.*)$")
+ANNOTATED_CONTEXT_PATTERN = re.compile(
+    r"^\[OLD:(?P<old>\d+),NEW:(?P<new>\d+)\] ?(?P<text>.*)$"
+)
+
+
+def normalize_review_path(value: Any) -> str:
+    path = str(value or "").strip()
+    path = re.sub(r"^(a/|b/|\./)", "", path)
+    return path
+
+
+def build_diff_maps_from_annotated_diff(
+    diff_text: str,
+) -> tuple[dict[str, dict[str, set[int]]], dict[str, dict[str, dict[int, str]]]]:
+    """Build validation maps from the annotated diff shown to review agents."""
+    diff_line_map: dict[str, dict[str, set[int]]] = {}
+    diff_content_map: dict[str, dict[str, dict[int, str]]] = {}
+    current_path = ""
+    old_path = ""
+
+    def ensure_path(path: str) -> None:
+        diff_line_map.setdefault(path, {"LEFT": set(), "RIGHT": set()})
+        diff_content_map.setdefault(path, {"LEFT": {}, "RIGHT": {}})
+
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("diff --git "):
+            current_path = ""
+            old_path = ""
+            continue
+        if raw_line.startswith("--- "):
+            candidate = raw_line[4:].strip()
+            old_path = (
+                "" if candidate == "/dev/null" else normalize_review_path(candidate)
+            )
+            continue
+        if raw_line.startswith("+++ "):
+            candidate = raw_line[4:].strip()
+            if candidate == "/dev/null":
+                current_path = old_path
+            else:
+                current_path = normalize_review_path(candidate)
+            if current_path:
+                ensure_path(current_path)
+            continue
+        if not current_path:
+            continue
+        old_match = ANNOTATED_OLD_PATTERN.match(raw_line)
+        if old_match:
+            line = int(old_match.group("old"))
+            text = old_match.group("text")
+            diff_line_map[current_path]["LEFT"].add(line)
+            diff_content_map[current_path]["LEFT"][line] = text
+            continue
+        new_match = ANNOTATED_NEW_PATTERN.match(raw_line)
+        if new_match:
+            line = int(new_match.group("new"))
+            text = new_match.group("text")
+            diff_line_map[current_path]["RIGHT"].add(line)
+            diff_content_map[current_path]["RIGHT"][line] = text
+            continue
+        context_match = ANNOTATED_CONTEXT_PATTERN.match(raw_line)
+        if context_match:
+            old_line = int(context_match.group("old"))
+            new_line = int(context_match.group("new"))
+            text = context_match.group("text")
+            diff_line_map[current_path]["LEFT"].add(old_line)
+            diff_line_map[current_path]["RIGHT"].add(new_line)
+            diff_content_map[current_path]["LEFT"][old_line] = text
+            diff_content_map[current_path]["RIGHT"][new_line] = text
+
+    return diff_line_map, diff_content_map
+
+
+def _extract_suggestion_blocks(body: str | None) -> list[list[str]]:
+    blocks: list[list[str]] = []
+    for match in SUGGESTION_BLOCK_PATTERN.finditer(body or ""):
+        content = match.group("content")
+        lines = [line.rstrip("\r") for line in content.split("\n")]
+        blocks.append(lines)
+    return blocks
+
+
+def _validate_suggestion_blocks(
+    comment: dict[str, Any],
+    diff_content_map: dict[str, dict[str, dict[int, str]]],
+) -> list[str]:
+    errors: list[str] = []
+    body = comment.get("body") or ""
+    blocks = _extract_suggestion_blocks(body)
+    if not blocks:
+        return errors
+
+    path = comment.get("path") or ""
+    side = comment.get("side") or "RIGHT"
+    start_side = comment.get("start_side") or side
+    line_no = comment.get("line")
+    if not isinstance(line_no, int):
+        return errors
+    start_line = comment.get("start_line") or line_no
+    content_for_start_side = diff_content_map.get(path, {}).get(start_side, {})
+    content_for_end_side = diff_content_map.get(path, {}).get(side, {})
+
+    for block_index, block_lines in enumerate(blocks):
+        if not block_lines or block_lines == [""]:
+            continue
+        prev_context = content_for_start_side.get(start_line - 1)
+        next_context = content_for_end_side.get(line_no + 1)
+        first_line = block_lines[0]
+        last_line = block_lines[-1]
+        if prev_context is not None and first_line == prev_context:
+            errors.append(
+                f"suggestion block {block_index} duplicates the context line immediately above "
+                f"`start_line` ({start_line - 1}); that line is not replaced and will appear twice after the suggestion is applied"
+            )
+        if next_context is not None and last_line == next_context:
+            errors.append(
+                f"suggestion block {block_index} duplicates the context line immediately below "
+                f"`line` ({line_no + 1}); that line is not replaced and will appear twice after the suggestion is applied"
+            )
+    return errors
+
+
+def validate_review_payload(
+    review: Any,
+    diff_line_map: dict[str, dict[str, set[int]]],
+    diff_content_map: dict[str, dict[str, dict[int, str]]] | None = None,
+) -> ReviewValidationResult:
+    """Validate a review.json payload against the annotated PR diff."""
+    if not isinstance(review, dict):
+        raise ValueError("Review payload must be a JSON object.")
+
+    raw_body = review.get("body")
+    if raw_body is None:
+        raw_body = review.get("summary") or ""
+    if not isinstance(raw_body, str):
+        raise ValueError("Review payload `body` must be a string.")
+
+    raw_comments = review.get("comments") or []
+    if not isinstance(raw_comments, list):
+        raise ValueError("Review payload `comments` must be a list.")
+
+    normalized_comments: list[ReviewComment] = []
+    errors: list[str] = []
+
+    for index, raw_comment in enumerate(raw_comments):
+        if not isinstance(raw_comment, dict):
+            errors.append(f"`comments[{index}]` must be an object.")
+            continue
+
+        path = normalize_review_path(raw_comment.get("path"))
+        line = raw_comment.get("line")
+        body_value = raw_comment.get("body")
+        body = body_value.strip() if isinstance(body_value, str) else ""
+        side = raw_comment.get("side")
+
+        if not path:
+            errors.append(f"`comments[{index}]` is missing `path`.")
+            continue
+        if path not in diff_line_map:
+            errors.append(
+                f"`comments[{index}]` references `{path}`, which is not part of the PR diff. Move that feedback to top-level `body` instead."
+            )
+            continue
+        if not isinstance(line, int) or line <= 0:
+            errors.append(
+                f"`comments[{index}]` for `{path}` must include a positive integer `line`."
+            )
+            continue
+        if side not in {"LEFT", "RIGHT"}:
+            errors.append(
+                f"`comments[{index}]` for `{path}:{line}` must include `side` set to `LEFT` or `RIGHT`."
+            )
+            continue
+        if not body:
+            errors.append(f"`comments[{index}]` for `{path}` is missing `body`.")
+            continue
+
+        allowed_lines = diff_line_map[path][side]
+        if line not in allowed_lines:
+            errors.append(
+                f"`comments[{index}]` references `{path}:{line}` on `{side}`, which is not commentable in the PR diff."
+            )
+            continue
+
+        normalized_comment: ReviewComment = {
+            "path": path,
+            "line": line,
+            "side": side,
+            "body": body,
+        }
+
+        if "start_line" in raw_comment and raw_comment.get("start_line") is not None:
+            start_line = raw_comment.get("start_line")
+            if not isinstance(start_line, int) or start_line <= 0:
+                errors.append(
+                    f"`comments[{index}]` for `{path}` has invalid `start_line`; it must be a positive integer."
+                )
+                continue
+            start_side = raw_comment.get("start_side")
+            if start_side not in {"LEFT", "RIGHT"}:
+                errors.append(
+                    f"`comments[{index}]` for `{path}` has `start_line` but is missing `start_side`; set `start_side` to `LEFT` or `RIGHT`."
+                )
+                continue
+            if start_side == side and start_line >= line:
+                errors.append(
+                    f"`comments[{index}]` for `{path}` has invalid `start_line`; when `start_side` matches `side`, it must be smaller than `line`."
+                )
+                continue
+            if start_line not in diff_line_map[path][start_side]:
+                errors.append(
+                    f"`comments[{index}]` references `{path}:{start_line}` on `{start_side}` as `start_line`, which is not commentable in the PR diff."
+                )
+                continue
+            normalized_comment["start_line"] = start_line
+            normalized_comment["start_side"] = start_side
+        elif raw_comment.get("start_side") is not None:
+            errors.append(
+                f"`comments[{index}]` for `{path}:{line}` has `start_side` without `start_line`."
+            )
+            continue
+
+        if diff_content_map is not None:
+            suggestion_errors = _validate_suggestion_blocks(
+                normalized_comment, diff_content_map
+            )
+            if suggestion_errors:
+                for err in suggestion_errors:
+                    errors.append(
+                        f"`comments[{index}]` for `{path}:{line}` on `{side}` has an invalid suggestion block: {err}."
+                    )
+                continue
+
+        normalized_comments.append(normalized_comment)
+
+    return ReviewValidationResult(
+        body=raw_body.strip(),
+        comments=normalized_comments,
+        errors=errors,
+    )
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"review validation failed: {path} does not exist")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"review validation failed: {path} is invalid JSON: {exc}")
+
+
+def _validate_verdict(payload: Any) -> list[str]:
+    if not isinstance(payload, dict):
+        return ["review.json must decode to a JSON object."]
+    verdict = payload.get("verdict")
+    if verdict not in {"APPROVE", "REJECT"}:
+        return ['`verdict` must be exactly "APPROVE" or "REJECT".']
+    return []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate review.json comments against annotated pr_diff.txt."
+    )
+    parser.add_argument(
+        "--review-json",
+        default="review.json",
+        type=Path,
+        help="Path to the review.json artifact to validate.",
+    )
+    parser.add_argument(
+        "--diff",
+        default="pr_diff.txt",
+        type=Path,
+        help="Path to the annotated PR diff consumed during review.",
+    )
+    args = parser.parse_args()
+
+    payload = _load_json(args.review_json)
+    try:
+        diff_text = args.diff.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"review validation failed: {args.diff} does not exist", file=sys.stderr)
+        return 1
+
+    diff_line_map, diff_content_map = build_diff_maps_from_annotated_diff(diff_text)
+    result = validate_review_payload(payload, diff_line_map, diff_content_map)
+    errors = _validate_verdict(payload) + result.errors
+    if errors:
+        print("review validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "review validation passed: "
+        f"{len(result.comments)} inline comment(s), {len(diff_line_map)} diff file(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/improve-review-pr.yml
+++ b/.github/workflows/improve-review-pr.yml
@@ -1,0 +1,102 @@
+name: Improve Review PR Skill
+
+# Daily outer loop over automated code review:
+# 1. Collect human reactions to review-pr comments from the last day
+# 2. Run an Oz agent with the improve-review-pr skill
+# 3. If durable organizational knowledge is found, open a PR updating the review skill
+#
+# Setup:
+# - WARP_API_KEY repository secret must be set
+# - Repository settings must allow GitHub Actions to create pull requests
+
+on:
+  schedule:
+    # 13:00 UTC daily
+    - cron: "0 13 * * *"
+  workflow_dispatch:
+    inputs:
+      since_hours:
+        description: "How many hours of review feedback to inspect"
+        required: false
+        default: "24"
+
+concurrency:
+  group: improve-review-pr
+  cancel-in-progress: false
+
+jobs:
+  improve:
+    name: Improve review-pr from human feedback
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect review feedback corpus
+        id: collect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SINCE_HOURS: ${{ github.event.inputs.since_hours || '24' }}
+        run: |
+          set -euo pipefail
+
+          python3 .agents/skills/improve-review-pr/scripts/collect_review_feedback.py \
+            --repo "${REPO}" \
+            --since-hours "${SINCE_HOURS}" \
+            --output feedback_corpus.json
+
+          echo "summary<<EOF" >> "$GITHUB_OUTPUT"
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          from pathlib import Path
+          data = json.loads(Path("feedback_corpus.json").read_text(encoding="utf-8"))
+          summary = data.get("summary") or {}
+          print(
+              f"PRs inspected: {summary.get('prs_inspected', 0)}; "
+              f"validated={summary.get('validated', 0)}, "
+              f"corrected={summary.get('corrected', 0)}, "
+              f"refined={summary.get('refined', 0)}, "
+              f"ambiguous={summary.get('ambiguous', 0)}"
+          )
+          PY
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Upload feedback corpus
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-feedback-corpus
+          path: feedback_corpus.json
+          if-no-files-found: error
+
+      - name: Improve review skill with Oz agent
+        uses: warpdotdev/oz-agent-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          skill: improve-review-pr
+          name: "Improve review-pr from last-day feedback"
+          prompt: |
+            Use the Improve Review PR skill to run the daily outer loop over automated code-review feedback.
+
+            First read `.agents/skills/improve-review-pr/SKILL.md`, then follow it exactly.
+
+            - Repository: ${{ github.repository }}
+            - Lookback window: ${{ github.event.inputs.since_hours || '24' }} hours
+            - Feedback corpus already prepared at `feedback_corpus.json`
+            - Feedback summary: ${{ steps.collect.outputs.summary }}
+
+            Analyze the corpus, synthesize durable organizational knowledge, and only if warranted:
+            update `.agents/skills/review-pr/SKILL.md` and/or create/update
+            `.agents/skills/review-pr-local/SKILL.md`, then open a pull request with those skill changes.
+
+            Do not change product code. Do not open a PR if there is no durable learning.
+            End with the report format required by the skill.
+          warp_api_key: ${{ secrets.WARP_API_KEY }}
+          profile: ${{ vars.WARP_AGENT_PROFILE || '' }}

--- a/.github/workflows/review-pull-requests.yml
+++ b/.github/workflows/review-pull-requests.yml
@@ -1,0 +1,253 @@
+name: Review Pull Requests
+
+# Reviews an opened or updated pull request with an Oz cloud agent.
+#
+# The agent runs with read-only GitHub permissions and writes structured
+# findings to review.json. A separate publish job validates that artifact
+# against the annotated diff and posts the GitHub review.
+#
+# Setup: the WARP_API_KEY repository secret must be set (the Oz API key).
+# Optional: enable "Allow GitHub Actions to create and approve pull requests"
+# in the repository/organization Actions settings if APPROVE review events
+# should succeed. Otherwise publish_review.py falls back to COMMENT for
+# approvals while still posting the review body and inline comments.
+#
+# review.json is passed between jobs via an artifact rather than a job output
+# so large reviews are not truncated by GitHub Actions' ~1 MB output limit.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: review-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Review pull request
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout pull request head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Prepare review artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin \
+            "${BASE_SHA}" \
+            "${HEAD_SHA}"
+
+          # Prefer the three-dot PR range so the annotated diff matches GitHub's
+          # pull request file view as closely as possible.
+          git diff --find-renames "${BASE_SHA}...${HEAD_SHA}" > raw_diff.txt
+
+          python3 .agents/skills/review-pr/scripts/annotate_diff.py \
+            --input raw_diff.txt \
+            --output pr_diff.txt
+
+          gh pr view "${PR_NUMBER}" --repo "${REPO}" --json title,body,baseRefName,headRefName,author,url > pr_meta.json
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          meta = json.loads(Path("pr_meta.json").read_text(encoding="utf-8"))
+          body = (meta.get("body") or "").strip() or "No description provided."
+          author = ((meta.get("author") or {}).get("login") or "unknown")
+          pr_number = os.environ["PR_NUMBER"]
+          text = (
+              f"# Pull Request #{pr_number}\n\n"
+              f"- Title: {meta.get('title') or ''}\n"
+              f"- Base branch: {meta.get('baseRefName') or ''}\n"
+              f"- Head branch: {meta.get('headRefName') or ''}\n"
+              f"- Author: {author}\n"
+              f"- URL: {meta.get('url') or ''}\n\n"
+              f"## Body\n\n{body}\n"
+          )
+          Path("pr_description.txt").write_text(text, encoding="utf-8")
+          PY
+
+          python3 .agents/skills/review-pr/scripts/resolve_spec_context.py \
+            --repo "${REPO}" \
+            --pr "${PR_NUMBER}" \
+            --workspace "${GITHUB_WORKSPACE}" \
+            --output spec_context.md || true
+
+          if [ ! -s spec_context.md ]; then
+            printf 'No approved or repository spec context was found for this PR.\n' > spec_context.md
+          fi
+
+          echo "Prepared review artifacts:"
+          wc -l raw_diff.txt pr_diff.txt pr_description.txt spec_context.md
+
+      - name: Upload review inputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-inputs-pr-${{ github.event.pull_request.number }}
+          path: |
+            pr_diff.txt
+            pr_description.txt
+            spec_context.md
+          if-no-files-found: error
+
+      - name: Review with Oz agent
+        uses: warpdotdev/oz-agent-action@v1
+        id: review
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          skill: review-pr
+          name: "Review PR #${{ github.event.pull_request.number }}"
+          prompt: |
+            Review GitHub pull request #${{ github.event.pull_request.number }} in this repository using the review-pr skill.
+
+            First read `.agents/skills/review-pr/SKILL.md`, then follow it exactly.
+
+            - Repository: ${{ github.repository }}
+            - Pull request URL: ${{ github.event.pull_request.html_url }}
+            - Base branch: ${{ github.event.pull_request.base.ref }}
+            - Head branch: ${{ github.event.pull_request.head.ref }}
+            - Head SHA: ${{ github.event.pull_request.head.sha }}
+
+            Local review artifacts are already prepared in the working directory:
+            - `pr_diff.txt`: annotated PR diff
+            - `pr_description.txt`: PR metadata and description
+            - `spec_context.md`: product/tech specs when resolvable
+
+            If `spec_context.md` only says no context was found, you may regenerate it with:
+            `python3 .agents/skills/review-pr/scripts/resolve_spec_context.py --repo ${{ github.repository }} --pr ${{ github.event.pull_request.number }} --output spec_context.md`
+
+            Review the PR, write `review.json` to the working directory, and validate it with:
+            `python3 .agents/skills/review-pr/scripts/validate_review_json.py --review-json review.json --diff pr_diff.txt`
+
+            Do not post the review to GitHub. Leave the validated `review.json` file in the working directory. Your final response may restate the JSON, but the on-disk `review.json` file is required.
+          warp_api_key: ${{ secrets.WARP_API_KEY }}
+          profile: ${{ vars.WARP_AGENT_PROFILE || '' }}
+
+      - name: Materialize review.json
+        env:
+          REVIEW_RESULT: ${{ steps.review.outputs.agent_output }}
+        run: |
+          set -euo pipefail
+
+          # Prefer the on-disk artifact written by the agent so large reviews are
+          # not limited by GitHub Actions job-output size.
+          if [ -f review.json ]; then
+            python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("review.json").read_text(encoding="utf-8"))
+          if not isinstance(payload, dict) or "verdict" not in payload or "comments" not in payload:
+              raise SystemExit("review.json exists but is missing required verdict/comments fields")
+          print(
+              f"Using on-disk review.json "
+              f"(verdict={payload.get('verdict')}, comments={len(payload.get('comments') or [])})"
+          )
+          PY
+            exit 0
+          fi
+
+          if [ -z "${REVIEW_RESULT:-}" ]; then
+            echo "::error::Review job produced neither review.json nor agent output." >&2
+            exit 1
+          fi
+
+          printf '%s' "$REVIEW_RESULT" > raw_output.txt
+
+          # Fallback: extract the last review-result object from the agent output.
+          if ! python3 - raw_output.txt > review.json <<'PY'
+          import json, sys
+
+          text = open(sys.argv[1], encoding="utf-8").read()
+          decoder = json.JSONDecoder()
+          last_obj = last_review = None
+          for i, ch in enumerate(text):
+              if ch != "{":
+                  continue
+              try:
+                  obj, _ = decoder.raw_decode(text[i:])
+              except json.JSONDecodeError:
+                  continue
+              if isinstance(obj, dict):
+                  last_obj = obj
+                  if "verdict" in obj and "comments" in obj:
+                      last_review = obj
+          result = last_review if last_review is not None else last_obj
+          if result is None:
+              sys.exit(1)
+          json.dump(result, sys.stdout)
+          PY
+          then
+            echo "::error::Could not find a review JSON object in the agent output. Raw output:" >&2
+            cat raw_output.txt >&2
+            exit 1
+          fi
+
+          echo "Materialized review.json from agent output fallback"
+
+      - name: Upload review result
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-result-pr-${{ github.event.pull_request.number }}
+          path: review.json
+          if-no-files-found: error
+
+  publish:
+    name: Publish review
+    needs: review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download review inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: review-inputs-pr-${{ github.event.pull_request.number }}
+
+      - name: Download review result
+        uses: actions/download-artifact@v4
+        with:
+          name: review-result-pr-${{ github.event.pull_request.number }}
+
+      - name: Publish review.json
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [ ! -f review.json ]; then
+            echo "::error::review.json artifact is missing." >&2
+            exit 1
+          fi
+          if [ ! -f pr_diff.txt ]; then
+            echo "::error::pr_diff.txt artifact is missing." >&2
+            exit 1
+          fi
+
+          python3 .agents/skills/review-pr/scripts/publish_review.py \
+            --review-json review.json \
+            --diff pr_diff.txt \
+            --repo "${REPO}" \
+            --pr "${PR_NUMBER}"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -63,16 +63,16 @@ const ogImage = new URL(
         <slot name="head" />
         <title>{title}</title>
     </head>
-    <body class="bg-gray-950 text-white text-base">
+    <body class="bg-surface text-text text-base">
         <RootElement
-            class="fixed inset-0 invisible bg-gray-950 opacity-0 z-30 data-visible:opacity-80 data-visible:visible transition-all"
+            class="fixed inset-0 invisible bg-surface opacity-0 z-30 data-visible:visible transition-all"
         />
         <Nav headings={headings} />
         <div class="min-h-[80dvh]">
             <slot />
         </div>
         <footer>
-            <p class="text-center py-8 text-sm">
+            <p class="text-center py-8 text-sm text-text-muted">
                 &copy; 2020-present Ben Holmes. All rights reserved.
             </p>
         </footer>
@@ -91,6 +91,12 @@ const ogImage = new URL(
             }
             article a:is(:hover, :focus) {
                 filter: brightness(1.25);
+            }
+
+            /* Keep the drawing overlay dimming theme-aware. */
+            body > :first-child[data-visible] {
+                opacity: 1;
+                background-color: var(--palette-overlay);
             }
         </style>
         <script>

--- a/src/layouts/tailwind.css
+++ b/src/layouts/tailwind.css
@@ -1,5 +1,79 @@
 @import "tailwindcss";
 
+/* Runtime palette tokens. Dark remains the default.
+   @theme maps these into Tailwind color utilities without circular refs. */
+:root {
+  color-scheme: dark;
+  --palette-surface: #030712; /* gray-950 */
+  --palette-surface-elevated: #111827; /* gray-900 */
+  --palette-surface-muted: #1f2937; /* gray-800 */
+  --palette-border: #374151; /* gray-700 */
+  --palette-text: #ffffff;
+  --palette-text-muted: #d1d5db; /* gray-300 */
+  --palette-text-subtle: #9ca3af; /* gray-400 */
+  --palette-overlay: rgb(3 7 18 / 0.8);
+  --palette-primary: #6200ff;
+  --palette-primary-light: #a08aff;
+  --palette-primary-contrast: #ffffff;
+  --palette-marker-red: #ff0000;
+  --palette-marker-blue: #0034ff;
+  --palette-marker-blue-light: color-mix(
+    in srgb,
+    var(--palette-marker-blue),
+    white 20%
+  );
+  --palette-marker-green: #16a34a; /* green-600 */
+}
+
+/* Light mode palette for OS preference or explicit data-theme="light". */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    color-scheme: light;
+    --palette-surface: #fafafa;
+    --palette-surface-elevated: #ffffff;
+    --palette-surface-muted: #f3f4f6; /* gray-100 */
+    --palette-border: #e5e7eb; /* gray-200 */
+    --palette-text: #111827; /* gray-900 */
+    --palette-text-muted: #4b5563; /* gray-600 */
+    --palette-text-subtle: #6b7280; /* gray-500 */
+    --palette-overlay: rgb(17 24 39 / 0.45);
+    --palette-primary: #4c00c9;
+    --palette-primary-light: #6d28d9; /* violet-700, readable on light surfaces */
+    --palette-primary-contrast: #ffffff;
+    --palette-marker-red: #dc2626;
+    --palette-marker-blue: #1d4ed8;
+    --palette-marker-blue-light: color-mix(
+      in srgb,
+      var(--palette-marker-blue),
+      white 25%
+    );
+    --palette-marker-green: #15803d;
+  }
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --palette-surface: #fafafa;
+  --palette-surface-elevated: #ffffff;
+  --palette-surface-muted: #f3f4f6;
+  --palette-border: #e5e7eb;
+  --palette-text: #111827;
+  --palette-text-muted: #4b5563;
+  --palette-text-subtle: #6b7280;
+  --palette-overlay: rgb(17 24 39 / 0.45);
+  --palette-primary: #4c00c9;
+  --palette-primary-light: #6d28d9;
+  --palette-primary-contrast: #ffffff;
+  --palette-marker-red: #dc2626;
+  --palette-marker-blue: #1d4ed8;
+  --palette-marker-blue-light: color-mix(
+    in srgb,
+    var(--palette-marker-blue),
+    white 25%
+  );
+  --palette-marker-green: #15803d;
+}
+
 @theme {
   --font-heading: var(--font-family-heading);
   --font-sans: var(--font-family-sans);
@@ -15,16 +89,19 @@
   --text-7xl: clamp(5.2rem, 3.94vw + 3.75rem, 6.4rem);
   --text-8xl: clamp(5.8rem, 4.14vw + 4.05rem, 7.2rem);
 
-  --color-marker-red: #ff0000;
-  --color-marker-blue: #0034ff;
-  --color-marker-blue-light: color-mix(
-    in srgb,
-    var(--color-marker-blue),
-    white 20%
-  );
-  --color-marker-green: var(--color-green-600);
-  --color-primary: #6200ff;
-  --color-primary-light: #a08aff;
+  --color-marker-red: var(--palette-marker-red);
+  --color-marker-blue: var(--palette-marker-blue);
+  --color-marker-blue-light: var(--palette-marker-blue-light);
+  --color-marker-green: var(--palette-marker-green);
+  --color-primary: var(--palette-primary);
+  --color-primary-light: var(--palette-primary-light);
+  --color-surface: var(--palette-surface);
+  --color-surface-elevated: var(--palette-surface-elevated);
+  --color-surface-muted: var(--palette-surface-muted);
+  --color-border: var(--palette-border);
+  --color-text: var(--palette-text);
+  --color-text-muted: var(--palette-text-muted);
+  --color-text-subtle: var(--palette-text-subtle);
 
   --width-prose: 60ch;
 


### PR DESCRIPTION
## Summary
- Port `review-pr` and `improve-review-pr` skills (with scripts) from `cloud-factory-demo`
- Add the matching GitHub Actions workflows: `review-pull-requests.yml` and `improve-review-pr.yml`
- Introduce a semantic light/dark color palette and wire the base layout to `bg-surface` / `text-text` tokens so light mode works via OS preference or `data-theme=\"light\"`

## Setup required for workflows
- Set repository secret `WARP_API_KEY`
- Optional: set repository variable `WARP_AGENT_PROFILE`
- For auto-approve reviews: enable “Allow GitHub Actions to create and approve pull requests”
- For the daily improve loop: allow GitHub Actions to create pull requests

## Test plan
- [ ] Confirm `.agents/skills/review-pr` and `.agents/skills/improve-review-pr` are present with scripts
- [ ] Open this PR and verify `Review Pull Requests` workflow can run once `WARP_API_KEY` is set
- [ ] Manually dispatch `Improve Review PR Skill` (or run the skill locally) after some review feedback exists
- [ ] Load the site in light OS appearance (or set `document.documentElement.dataset.theme = 'light'`) and confirm page background/text/footer use the light palette
- [ ] Confirm dark mode still looks correct with default preference / `data-theme=\"dark\"`